### PR TITLE
Fix the joke on ADA vs Ada

### DIFF
--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -20,7 +20,7 @@ The Name
 
    - Drafted a plan of how Charles Babbage's Analytical Engine might calculate Bernoulli numbers, now considered the first computer program
 
-* Writing Ada is like writing C++
+* Writing "ADA" is like writing "CPLUSPLUS"
 
    - The cognoscenti will know...
 


### PR DESCRIPTION
As discussed, the joke is that some people mistype ADA thinking it's an acronym instead of Ada since this if a first name.