### PR TITLE
Add --fail-if-warnings options to pandoc

### DIFF
--- a/courses/fundamentals_of_ada/120a_advanced_privacy.rst
+++ b/courses/fundamentals_of_ada/120a_advanced_privacy.rst
@@ -390,7 +390,7 @@ Children "Inherit" From Private Properties Of Parent
 Lab
 ========
 
-.. include:: labs/advanced_privacy.lab.rst
+.. include:: labs/120a_advanced_privacy.lab.rst
 
 =========
 Summary

--- a/courses/fundamentals_of_ada/180a_multiple_inheritance.rst
+++ b/courses/fundamentals_of_ada/180a_multiple_inheritance.rst
@@ -153,7 +153,7 @@ Limited Tagged Types And Interfaces
 Lab
 ========
 
-.. include:: labs/multiple_inheritance.lab.rst
+.. include:: labs/180a_multiple_inheritance.lab.rst
 
 =========
 Summary

--- a/courses/fundamentals_of_ada/labs/180_polymorphism.lab.rst
+++ b/courses/fundamentals_of_ada/labs/180_polymorphism.lab.rst
@@ -1,3 +1,5 @@
+.. |rightarrow| replace:: :math:`\rightarrow`
+
 ------------------
 Polymorphism Lab
 ------------------

--- a/pandoc/pandoc_fe.py
+++ b/pandoc/pandoc_fe.py
@@ -259,6 +259,7 @@ if __name__== "__main__":
                             pandoc_title_arg,
                             theme,
                             color,
+                            '--fail-if-warnings',
                             '-f rst',
                             '-t ' + output_format ( args.extension.lower() ),
                             '-o ' + output_file, *source_list)


### PR DESCRIPTION
# Pandoc fails on errors

With this option pandoc will fail when trying to eg include an image that does not exist, or use an undefined directive or symbol.