### PR TITLE
Remove deprecated tooling, rename Spark -> SPARK

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,22 +67,22 @@ jobs:
           path: out/fundamentals_of_ada/standard_course.pdf
 
 
-      - name: Generate slides for Spark
+      - name: Generate slides for SPARK
         run: python pandoc/pandoc_fe.py --output-dir out/spark_for_ada_programmers --hush --extension pdf --source courses/spark_for_ada_programmers/*.rst
 
-      - name: Package and upload Spark slides
+      - name: Package and upload SPARK slides
         uses: actions/upload-artifact@v2
         with:
-          name: Spark for Ada programmers
+          name: SPARK for Ada programmers
           path: out/spark_for_ada_programmers/*.pdf
 
-      - name: Generate standard Spark course
+      - name: Generate standard SPARK course
         run: python pandoc/pandoc_fe.py --extension pdf --source courses/spark_for_ada_programmers/course.txt --output-dir out/spark_for_ada_programmers
 
-      - name: Package and upload standard Spark course
+      - name: Package and upload standard SPARK course
         uses: actions/upload-artifact@v2
         with:
-          name: Standard Spark course
+          name: Standard SPARK course
           path: out/spark_for_ada_programmers/course.pdf
 
       - name: Lab Radar PDF and package

--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -702,7 +702,7 @@ Canonical First Program
 
    - In a command prompt shell, go to where the new file is located and issue the following command:
 
-      + :command:`gnatmake say_hello`
+      + :command:`gprbuild say_hello`
 
 * In the same shell, invoke the resulting executable:
 

--- a/courses/fundamentals_of_ada/200_elaboration.rst
+++ b/courses/fundamentals_of_ada/200_elaboration.rst
@@ -160,7 +160,7 @@ GNAT Static Elaboration Model
 
 * Performed by :command:`gnatbind`
 
-   - Automatically called by a builder (:command:`gnatmake` or :command:`gprbuild`)
+   - Automatically called by a builder (:command:`gprbuild`)
    - Reads ALI files from the closure
    - Generates :filename:`b_xxx.ad[sb]` or :filename:`b__xxx.ad[sb]` files
    - Contains elaboration and finalization procedures

--- a/courses/fundamentals_of_ada/905_gnat_options.rst
+++ b/courses/fundamentals_of_ada/905_gnat_options.rst
@@ -20,13 +20,13 @@ Understanding the GNAT Build Steps
 
    - package `Linker` of the gpr file
 
-* **gprbuild** (as well as **gnatmake**) is responsible of calling these tools
+* **gprbuild** is responsible of calling these tools
 
 ----------------------
 Targets and Runtimes
 ----------------------
 
-* Most tools have a "native" name (gcc, gnat, gnatmake, gnatcheck, etc.)
+* Most tools have a "native" name (gcc, gnat, gnatcheck, etc.)
 * The name of the tool for the target is "**target**-**toolname**"
 
    - powerpc-wrs-vxworksae-gcc

--- a/courses/fundamentals_of_ada/905_gnat_options.rst
+++ b/courses/fundamentals_of_ada/905_gnat_options.rst
@@ -32,7 +32,7 @@ Targets and Runtimes
    - powerpc-wrs-vxworksae-gcc
    - powerpc-wrs-vxworksae-gnatcheck
 
-* Exceptions: gnatstack, gprbuild, gps
+* Exceptions: gnatstack, gprbuild, gnatstudio
 * The runtime is introduced with the **--RTS=** switch
 
    - powerpc-wrs-vxworksae-gcc --RTS=zfp
@@ -99,7 +99,7 @@ Data representation
 * Code is expanded into simple structures and system calls
 * Useful to understand the complexity of the Ada constructions
 * Useful to identify check locations
-* Integrated into GPS
+* Integrated into GNAT Studio
 
 -----------------------------
 Intermediate representation

--- a/courses/fundamentals_of_ada/910_gpr_basics.rst
+++ b/courses/fundamentals_of_ada/910_gpr_basics.rst
@@ -103,7 +103,7 @@ About Project Files and Makefiles
 
 .. code:: console
 
-   gnatmake -P <project-file> ...
+   gprbuild -P <project-file> ...
  
 ===============================
 Configuring Project Properties
@@ -178,7 +178,7 @@ Typed Versus Untyped Variables
 
 * **Builder**
 
-   - *gnatmake* or *gprbuild*
+   - *gprbuild*
 
 * **Compiler**
 
@@ -455,8 +455,8 @@ External and Conditional References
 
 .. code:: console
 
-   gnatmake -P... -Xname=value  ...
-   gnatmake -P/common/build.gpr -Xtarget=test  /common/main.adb
+   gprbuild -P... -Xname=value  ...
+   gprbuild -P/common/build.gpr -Xtarget=test  /common/main.adb
  
 ----------------------------------------
 External/Conditional Reference Example

--- a/courses/fundamentals_of_ada/915_predefined_libraries.rst
+++ b/courses/fundamentals_of_ada/915_predefined_libraries.rst
@@ -19,7 +19,7 @@ Ada Top-Level Namespace
    - GNAT
 
 * Binding generators and support for inter-language interfacing can make libraries in other languages accessible to Ada and vice versa
-* Full hierarchy (language-defined and GNAT) is browsable from GPS Help menu
+* Full hierarchy (language-defined and GNAT) is browsable from GNAT Studio Help menu
 
 ---------------------
 Ada.* Hierarchy (1)

--- a/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
+++ b/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
@@ -477,7 +477,7 @@ Does your loop terminate?
  
 .. container:: speakernote
 
-   There is an example of this in GPS we can look at if we want to.
+   There is an example of this in GNAT Studio we can look at if we want to.
    The sharper students might point out that the 'Increases I' isn't actually needed and you can still prove termination with just 'Decreases R'.
    This is true, and it would be nice to come up with a better example!
    You could do something such as changing the first assignment to:

--- a/courses/spark_for_ada_programmers/labs/020_formal_methods_and_spark.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/020_formal_methods_and_spark.lab.rst
@@ -4,7 +4,7 @@ Getting Started Lab
 
 * Requirements
 
-   - Install a *consistent* set of GNAT, GPS and the SPARK toolset.
+   - Install a *consistent* set of GNAT, GNAT Studio and the SPARK toolset.
    - Make sure that :toolname:`GNATstudio` and :toolname:`GNATprove` are on your PATH.
    - Start :toolname:`GNATstudio` and create a *Simple Ada Project*
    - Modify `Main` procedure so that it is in SPARK


### PR DESCRIPTION
* Remove `gnatmake` (replaced by `gprbuild`)
* GPS -> GNAT Studio
* Spark -> SPARK (piggy backing on the PR)

See #1 