### PR TITLE
Remove expression functions

### DIFF
--- a/courses/fundamentals_of_ada/120_limited_types.rst
+++ b/courses/fundamentals_of_ada/120_limited_types.rst
@@ -381,24 +381,18 @@ Quiz
          F2 : Character;
       end record;
       Zero : T := (0, ' ');
+      One : constant T := (1, 'a');
+      Two : T;
       function F return T;
    end P;
 
 Which is a correct completion of F?
 
-A. :answermono:`function F return T is ((3, 'c'));`
-B. | ``function F return T is``
-   |   ``Two : T;``
-   | ``begin``
-   |   ``Two := (2, 'b');``
-   |   ``return Two;``
-   | ``end F;``
-C. | ``function F return T is``
-   |   ``One : constant T := (1, 'a');``
-   | ``begin``
-   |   ``return One;``
-   | ``end F;``
-D. ``function F return T is ( Zero );``
+A. :answermono:`return (3, 'c');`
+B. | ``Two := (2, 'b');``
+   | ``return Two;``
+C. ``return One;``
+D. ``return Zero;``
 
 .. container:: animate
 

--- a/courses/fundamentals_of_ada/130_program_structure.rst
+++ b/courses/fundamentals_of_ada/130_program_structure.rst
@@ -730,11 +730,11 @@ Quiz
 
   .. container:: column
 
-   Which is not a legal completion of P.Child.X?
+   Which return statement would be illegal in P.Child.X?
 
-      A.  ``function X return Integer is (Object_A);``
-      B.  ``function X return Integer is (Object_B);``
-      C.  :answermono:`function X return Integer is (Object_C);`
+      A.  ``return Object_A;``
+      B.  ``return Object_B;``
+      C.  ``return Object_C;``
       D.  None of the above
 
    .. container:: animate

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -300,9 +300,9 @@ Calls on class-wide types (3/3)
 
       Root * V1 = new Root ();
       Root * V2 = new Child ();
-      ((Root) *V1).P ();
+      ((Root) *V1).P ())
       ((Root) *V2).P ();
- 
+
 -------------------------------
 Definite and class wide views
 -------------------------------
@@ -377,18 +377,25 @@ Quiz
 
 .. code::Ada
 
-   package P is
-      type Root is tagged null record;
-      function F1 (V : Root) return Integer is (101);
-      type Child is new Root with null record;
-      function F1 (V : Child) return Integer is (201);
-      type Grandchild is new Child with null record;
-      function F1 (V : Grandchild) return Integer is (301);
-   end P;
+   type Root is tagged null record;
+   function F1 (V : Root) return Integer is
+   begin
+     return 101;
+   end F1;
+   
+   type Child is new Root with null record;
+   function F1 (V : Child) return Integer is
+   begin
+     return 201;
+   end F1;
 
-   with P1; use P1;
-   procedure Main is
-      Z : Root'Class := Grandchild'(others => <>);
+   type Grandchild is new Child with null record;
+   function F1 (V : Grandchild) return Integer is
+   begin
+      return 301;
+   end F1;
+
+   Z : Root'Class := Grandchild'(others => <>);
 
 What is the value returned by :ada:`F1 (Child'Class (Z));`?
 

--- a/courses/fundamentals_of_ada/200_elaboration.rst
+++ b/courses/fundamentals_of_ada/200_elaboration.rst
@@ -347,7 +347,10 @@ Examples
    end P1;
    with P1;
    package body P2 is
-      function Call return Integer is ( P1.Call );
+      function Call return Integer is
+      begin
+         return P1.Call;
+      end Call;
    end P2;
    with P2;
    pragma Elaborate (P2);
@@ -377,7 +380,10 @@ Examples
    end P1;
    with P1;
    package body P2 is
-      function Call return Integer is ( P1.Call );
+      function Call return Integer is
+      begin
+         return P1.Call;
+      end Call;
    end P2;
    with P2;
    pragma Elaborate_All (P2);

--- a/courses/fundamentals_of_ada/215_type_contracts.rst
+++ b/courses/fundamentals_of_ada/215_type_contracts.rst
@@ -192,7 +192,10 @@ Default Type Initialization for Invariants
      -- Type is not a record, so we need to use aspect
      -- (A record could use default values for its components)
      type T is new Integer with Default_Value => 0; 
-     function Zero (This : T) return Boolean is (This = 0);
+     function Zero (This : T) return Boolean is
+     begin
+        return (This = 0);
+     end Zero;
    end P;
  
 ---------------------------------

--- a/courses/fundamentals_of_ada/240_tasking.rst
+++ b/courses/fundamentals_of_ada/240_tasking.rst
@@ -377,7 +377,10 @@ Protected Object Types
    end Register_T;
 
    protected body Register_T is
-      function Read return Integer is (Register);
+      function Read return Integer is
+      begin
+         return Register;
+      end Read;
       procedure Write (Value : Integer) is
       begin
          Register := Value;


### PR DESCRIPTION
Expression functions are a bit overused in the example, but they are an Ada 2012 construct and they are not introduced until later in the course. This set of commit replaces them with full expressions while trying to not make the slides too verbose.