### PR TITLE
Update course, fix typos and remove whitespace at end of lines

### DIFF
--- a/courses/spark_for_ada_programmers/010_course_overview.rst
+++ b/courses/spark_for_ada_programmers/010_course_overview.rst
@@ -14,7 +14,7 @@ Motivating Example
 * Consider these lines of code from the original release of the Tokeneer code
 
    .. code:: Ada
-    
+
       if Success and then
           (RawDuration * 10 <= Integer(DurationT'Last) and
            RawDuration * 10 >= Integer(DurationT'First))
@@ -28,7 +28,7 @@ Motivating Example
 .. container:: speakernote
 
    Overflow can happen before check
-     
+
 ------------------------
 The Verifying Compiler
 ------------------------
@@ -51,7 +51,7 @@ The Verifying Compiler
    It exists. GNATprove. This is what we will talk about.
 
 ------------------------------------------------
-Static Verification and Programming Languages 
+Static Verification and Programming Languages
 ------------------------------------------------
 
 * There is a catch...
@@ -69,7 +69,7 @@ Static Verification Goals
    - Fast (tells you now)
    - Complete (with as few false alarms/positives as possible)
 
-   - Modular and Constructive (works on incomplete programs) 
+   - Modular and Constructive (works on incomplete programs)
 
 * SPARK is designed with these goals in mind. Since the eighties!
 
@@ -110,13 +110,13 @@ Course Contents
 =================
 
 -----------------
-Course Outline 
+Course Outline
 -----------------
 
 .. container:: columns
 
  .. container:: column
-  
+
     * Course Introduction
     * SPARK Rationale And Overview
 
@@ -132,11 +132,11 @@ Course Outline
     * Introduction to Proof
 
        - Proving Programs Correct
-       - Proving Abscence of Run-Time Errors
+       - Proving Absence of Run-Time Errors
        - The Proof Cycle
 
  .. container:: column
-  
+
     * Advanced Verification
 
        - Advanced Proof
@@ -164,8 +164,8 @@ Course Goals
 
 * What will you do after the course?
 
-   - Be comfortable with the fundamentals of SPARK. 
+   - Be comfortable with the fundamentals of SPARK.
 
-   - Know where to find our more.
+   - Know where to find out more.
    - Let SPARK work for you on your next project?
    - ... ?

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -16,7 +16,7 @@ High-Integrity Software
 
    - More than cost, time-to-market, etc.
 
-* Must be known to be reliable before deployed
+* Must be known to be reliable before being deployed
 
    - With extremely low failure rates, e.g., 1 in 10:superscript:`9` hours (114,080 years)
    - Testing is insufficient and/or infeasible for such rates
@@ -55,18 +55,18 @@ Formal Methods
    How to specify formally the error messages from a compiler are readable, understandable, useful, etc?
 
 ------------------------------------------
-Combining Proof and Test - Cost Benefit 
+Combining Proof and Test - Cost Benefit
 ------------------------------------------
 
 .. container:: columns
 
  .. container:: column
-  
+
     * 80/20 rule holds for both test and proof activities
     * Same area of code is usually not both difficult to prove and difficult to test
 
  .. container:: column
-  
+
     .. image:: ../../images/80-20_provable_or_testable.png
 
 -------------------------------------
@@ -79,7 +79,7 @@ Language Facilitates Proof and Test
 
    - Additional aliasing detection beyond Ada RM requirements
 
-   - Additional data initialization and validity checks beyond Ada RM requirements 
+   - Additional data initialization and validity checks beyond Ada RM requirements
 
    - See the SPARK User's Guide for more details
 
@@ -114,10 +114,10 @@ The Programming Language
 
 * Excluded from SPARK:
 
-   - Access types designating data not on the heap
+   - Aliasing data-structures obtained using access types
    - Expressions (including function calls) with side-effects
    - Aliasing of names
-   - Goto statements
+   - Backwards goto statements
    - Controlled types
    - Handling of exceptions (raise statements can be used in a program but proof will attempt to show that they cannot be executed)
 
@@ -125,8 +125,8 @@ The Programming Language
 
    At this point it helps to understand the rationale behind the differences between the SPARK and Ada languages.
    The aim while designing the SPARK subset of Ada was to create the biggest possible subset still amenable to easy specification and sound verification.
-   The most notable exclusions include access type and allocators, as well as handling of exceptions, which are both known to increase considerably the amount of required user-written annotations.
-   Goto statements and controlled types are also not supported as they introduce non-trivial control flow. 
+   The most notable exclusions include uses of access type and allocators that create aliasing, as well as handling of exceptions, which are both known to increase considerably the amount of required user-written annotations.
+   Backwards goto statements and controlled types are also not supported as they introduce non-trivial control flow.
    The two remaining restrictions are side-effects in expressions and aliasing of names, which we will now look at in more detail.
 
 ------------------------------
@@ -135,7 +135,7 @@ Math Hidden Behind the Tools
 
 * Typical for engineering disciplines
 
-   - Engineer working with tool can ignore details of heavy-duty math required 
+   - Engineer working with tool can ignore details of heavy-duty math required
 
 * This is a simulation of the NASA Space Launch System
 
@@ -192,12 +192,12 @@ SPARK Contract Examples
                 and then Extent(This) = Extent(This'Old)+1,
      Global  => null,            -- data dependency
      Depends => (This =>+ Item); -- flow dependency
-   
+
    function Full (This : Stack) return Boolean;
    function Empty (This : Stack) return Boolean;
    function Top_Element (This : Stack) return Element;
    function Extent (This : Stack) return Element_Count;
- 
+
 .. container:: speakernote
 
    This example is just to give a feel for how contracts look and are expressed. The details will be covered later.
@@ -226,7 +226,7 @@ Objective: Data And Control Coupling
 
 * **Data coupling**
 
-   - "The dependence of a software component on data not exclusively under the control of that software component" 
+   - "The dependence of a software component on data not exclusively under the control of that software component"
 
 * **Control coupling**
 
@@ -251,7 +251,7 @@ How SPARK Addresses Data Coupling
 
          procedure Add_To_Total (X : in Integer) with
             Global => (In_Out => Total);
- 
+
    - Total is a global variable both read and written
 
 * Flow dependency contracts specify exactly how data influence subprogram output values
@@ -260,8 +260,8 @@ How SPARK Addresses Data Coupling
 
          procedure Add_To_Total (X : in Integer) with
             Depends => (Total => (Total, X));
- 
-   - Value of `Total` depends on inputs `Total` and `X`
+
+   - Value of output `Total` depends on inputs `Total` and `X`
 
 --------------------------------------
 How SPARK Addresses Control Coupling
@@ -275,14 +275,14 @@ How SPARK Addresses Control Coupling
 
          procedure Add_To_Total (X : in Integer) with
             Depends => (Total => (Total, X));
- 
+
 * Functional contracts specify the behavior of a subprogram, which defines how it "influences the execution of another software component"
 
       .. code:: Ada
 
          procedure Add_To_Total (X : in Integer) with
             Pre => X >= 0 and then Total <= Integer'Last - X;
- 
+
 .. container:: speakernote
 
    As a global, Total's value must affect some other unit
@@ -291,7 +291,7 @@ How SPARK Addresses Control Coupling
 Objective: Absence of Run-Time Errors
 ---------------------------------------
 
-* SPARK defines a number of run-time checks, and users can define their own too
+* SPARK defines a number of run-time checks, and users can define their own too (e.g., through assertions)
 
    - E.g., valid array indexing
 
@@ -317,8 +317,8 @@ Why Do We Care About Integer Overflow?
       .. code:: Ada
 
          Midpoint = (Low + High) / 2
- 
-* Security vulnerabilities 
+
+* Security vulnerabilities
 
    - PHP's `Msg_Receive()` function
 
@@ -367,7 +367,7 @@ Removing Run-Time Checks In SPARK
 
          procedure Increment (X : in out Integer) with
            Pre => X < Integer'Last;
- 
+
 * Therefore, you must either prove preconditions will hold or enable checks at run-time
 * Details discussed in the dedicated AoRTE section...
 
@@ -402,15 +402,15 @@ Proving Arbitrary Abstract Properties Example
 -----------------------------------------------
 
 .. code:: Ada
-    
+
    --Absence of Run-Time Errors
-   function Index (Input : List;
+   function Index (Input  : List;
                    Target : Natural)
-                   return Natural with 
+                   return Natural with
      Post => Index'Result in 0 | Input'Range;
-       
+
    --Correctness
-   function Index (Input : List;
+   function Index (Input  : List;
                    Target : Natural)
                    return Natural with
      Post => (if not Found (Target, Within => Input) then
@@ -419,7 +419,7 @@ Proving Arbitrary Abstract Properties Example
                  Index'Result in Input'Range
                  and then
                  Input (Index'Result) = Target);
-     
+
 .. container:: speakernote
 
    For example, to ensure no runtime error is raised when using the result of function Index, it may be enough to know that, whenever it is not 0, then it is in Input's range.
@@ -431,20 +431,20 @@ Proof Using Abstract Properties
 
 .. code:: Ada
 
-      function Index (Input : List;
-                      Target : Natural)
-                      return Natural
-        with Post =>
-               (if not Found (Target, Within => Input)
-                   then Index'Result = 0
-                else Index'Result in Input'Range and then
-                     Input (Index'Result) = Target);
+   function Index (Input  : List;
+                   Target : Natural)
+                   return Natural
+     with Post =>
+            (if not Found (Target, Within => Input)
+                then Index'Result = 0
+             else Index'Result in Input'Range and then
+                  Input (Index'Result) = Target);
    ...
       -- the target (ie array component) of the search
       T : constant Natural := 42;
       -- arbitrary but containing T
       L : constant List := (0, 0, T, others => 1);
-      I : Natural;  -- an index value for L  
+      I : Natural;  -- an index value for L
    begin
       I := Index (L, T);
       if I /= 0 then
@@ -455,7 +455,7 @@ Proof Using Abstract Properties
       end if;
       ...
    end Test;
- 
+
 .. container:: speakernote
 
    Pragma assert generates two info messages:
@@ -495,13 +495,13 @@ Components Integration: Defensive Code
 ------------------------------------------------
 Components Integration: Defensive Code Example
 ------------------------------------------------
-  
+
 .. code:: Ada
-    
+
    function Full (This : Stack)
                   return Boolean;
-       
-   procedure Push (This : in out Stack;
+
+          procedure Push (This  : in out Stack;
                    Value : Content) is
    begin
       if Full (This) then
@@ -509,12 +509,12 @@ Components Integration: Defensive Code Example
       end if;
       ...
    end Push;
-       
-   procedure Push (This : in out Stack;
+
+   procedure Push (This  : in out Stack;
                    Value : Content)
-      with   Pre     => not Full (This),
-             Post   => ...
-     
+      with   Pre  => not Full (This),
+             Post => ...
+
 ----------------------------------------
 Objective: Combining Proof and Testing
 ----------------------------------------
@@ -548,9 +548,9 @@ Combined Proof and Test
    - Integration testing will remain vital
 
 * Goal is to reach a level of confidence as good as the level reached by testing alone
-* Industrial use as of 2009
+* Industrial use
 
-   - E.g., Airbus for avionics software
+   - E.g., Airbus for avionics software, Altran for military software, etc.
 
 ========
 Lab

--- a/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
@@ -96,7 +96,7 @@ Use of Uninitialized Variables
       begin
          Inner; -- This is the error!
       end Outer;
- 
+
 .. container:: speakernote
 
    Each example shows a different example of use of an uninitialized variable that can be detected by the tools.
@@ -109,21 +109,22 @@ Ineffective Statements
 .. container:: columns
 
  .. container:: column
-  
+
     .. code:: Ada
-    
-       procedure P (
-             X, Y : in Integer;
-             Z : out Integer) is
+
+       procedure P
+         (X, Y : in Integer;
+          Z    : out Integer)
+       is
           T : Integer;
        begin
           T := X + 1;
           T := T + Y;
           Z := 3;
        end P;
-     
+
  .. container:: column
-  
+
     * Have no effect on any output variable
 
        - Therefore no effect on behavior of code
@@ -144,13 +145,13 @@ Detecting Unused Variables
    Tmp : Integer;
    procedure Swap2 (X, Y : in out Integer) is
      Temp : Integer := X;
-     -- warning: initialization of Temp has no effect
+     -- warning: initialization of "Temp" has no effect
      -- warning: variable "Temp" is not referenced
    begin
      X := Y;
      Y := Tmp;
    end Swap2;
- 
+
 .. container:: speakernote
 
    Probably a spelling error!
@@ -172,9 +173,9 @@ Incorrect Parameter Mode
 
   * - |checkmark|
 
-    - 
+    -
 
-    - 
+    -
 
     - in
 
@@ -186,17 +187,17 @@ Incorrect Parameter Mode
 
     - in out
 
-  * - 
+  * -
 
     - |checkmark|
 
-    - 
+    -
 
     - in out
 
-  * - 
+  * -
 
-    - 
+    -
 
     - |checkmark|
 
@@ -212,7 +213,7 @@ Incorrect Parameter Mode
      Y := X;   -- The initial value of Y is not used
      X := Tmp; -- Y is computed to be out
    end Swap;
- 
+
 .. container:: speakernote
 
    Parameter modes influence the behavior of the compiler and are a key point for documenting the usage of a subprogram.
@@ -232,15 +233,15 @@ Flow Analysis - Why Do We Care?
 
 * A common source of errors
 
-   - See CWE (Common Weakness Enumeration)/SANS list of "Most Dangerous Software Errors" 
+   - See CWE (Common Weakness Enumeration)/SANS list of "Most Dangerous Software Errors"
 
    - http://cwe.mitre.org/top25/
 
 * Ensure there is no dead code
 
-* Improper initialization errors are listed as one of the most dangerous programming errors 
+* Improper initialization errors are listed as one of the most dangerous programming errors
 
-   - The SPARK flow analysis identifies all variables that have not been initialized prior to them being read. 
+   - The SPARK flow analysis identifies all variables that have not been initialized prior to them being read.
 
    - If the SPARK flow analysis finds no uninitialized variables, then there really are none!
 
@@ -278,7 +279,7 @@ Modularity
        X := Y + Z;
      end if;
    end Set_X_To_Y_Plus_Z;
- 
+
 .. container:: speakernote
 
    Flow analysis is a sound analysis, which means that, if it does not output any message on some analyzed SPARK code, then none of the supported errors may occur in this code.
@@ -286,8 +287,8 @@ Modularity
    The first, and maybe most common, reason for this has to do with modularity.
    To improve efficiency on large projects, verifications are in general done on a per subprogram basis.
    It is in particular the case for detection of uninitialized variables.
-   For this detection to be done modularly, flow analysis needs to assume initialization of inputs on subprogram entry and initialization of outputs after subprogram calls. 
-   Therefore, every time a subprogram is called, flow analysis will check that global and parameter inputs are initialized, and every time a subprogram returns, it will check that global and parameter outputs are initialized. 
+   For this detection to be done modularly, flow analysis needs to assume initialization of inputs on subprogram entry and initialization of outputs after subprogram calls.
+   Therefore, every time a subprogram is called, flow analysis will check that global and parameter inputs are initialized, and every time a subprogram returns, it will check that global and parameter outputs are initialized.
    This may lead to messages being issued on perfectly correct subprograms like SetXToYPlusZ which only sets its out parameter X when Overflow is false.
    This simply means that, in that case, flow analysis was not able to verify that no uninitialized variable could be read.
    To solve this problem, X can either be set to a dummy value when there is an overflow or the user can verify by her own means that X is never used after a call to SetXToYPlusZ if Overflow is True.
@@ -313,7 +314,7 @@ Value Dependency
    end Absolute_Value;
 
 * Flow analysis does not know that `R` is initialized
- 
+
 .. code:: Ada
 
    procedure Absolute_Value (X : Integer; R : out Natural) is
@@ -324,9 +325,9 @@ Value Dependency
        R := X;
      end if;
    end Absolute_Value;
-   
+
 * Flow analysis knows that `R` is initialized
- 
+
 .. container:: speakernote
 
    It is also worth noting that flow analysis is not value dependent, in the sense that it never reasons about values of expressions.
@@ -346,7 +347,7 @@ Flow Analysis of Composite Objects
 
 * Records
 
-   - Updating and reading of fields of records is analyzed in terms of those fields 
+   - Updating and reading of fields of records is analyzed in terms of those fields
 
    - Updates and reads not treated as operations on records in their entirety
 
@@ -366,7 +367,7 @@ Arrays and Flow Analysis
       type T is array (Index) of Boolean;
       A    : T;
       I, J : Index;
- 
+
 * (An array with one element is not very interesting!)
 
 ----------------------------------
@@ -378,7 +379,7 @@ Array Elements and Flow Analysis
    .. code:: Ada
 
       A (I) := True;
- 
+
 * The final value of `A` might be (True, y) or (x, True) depending on the value of `I`
 * Note that at least one element of the initial value is preserved in both cases
 * So the final value of `A` must depend on:
@@ -396,7 +397,7 @@ Array Element Assignment
 
       A (I) := True;
       A (J) := True;
- 
+
 * Three possible outcomes:
 
 |
@@ -420,7 +421,7 @@ Array Assignment
          A (1) := True; -- flow error
          A (2) := True;
       end Init_Array;
- 
+
 * Don't "fix" this by changing the mode of `A` to `in out`
 
 ----------------------
@@ -435,7 +436,7 @@ Array Initialization
       begin
          A := (1 .. 2 => True);
       end Init_Array;
- 
+
    - (`others` could be used in this particular instance)
 
 * Flow analysis knows that the array must be fully defined by the aggregate, so no errors are reported
@@ -451,13 +452,13 @@ Flow Analysis Using :toolname:`GNATprove`
 .. container:: columns
 
  .. container:: column
-  
+
     * From the command line:
 
        - :command:`gnatprove --mode=flow`
 
  .. container:: column
-  
+
     .. image:: ../../images/spark_menu-examine_file.jpeg
 
 ========

--- a/courses/spark_for_ada_programmers/050_quantified_expressions.rst
+++ b/courses/spark_for_ada_programmers/050_quantified_expressions.rst
@@ -62,16 +62,16 @@ Component-Based Iteration Controls
       for name of [reverse] object loop
          ...
       end loop;
-     
-- Object is an array or iterable container
+
+- Object is an array or iterable (formal) container
 - Starts with first element unless you reverse it
 
 .. code:: Ada
 
-   Values : constant array (1 .. 10) of boolean := (...);
-   
+   Values : constant array (1 .. 10) of Boolean := (...);
+
    for V of Values loop
-      Put_Line ( boolean'image ( V ) );
+      Put_Line ( Boolean'Image ( V ) );
    end loop;
 
 ------------------------------------
@@ -80,24 +80,24 @@ Index-Based Iteration Controls
 
 - Declares an object that takes on successive values of a discrete type
 - Syntax indicates range of discrete indices
-    
+
    .. code:: Ada
-    
+
       for name in [reverse] range_def loop
          ...
       end loop;
-     
+
 - Starts with first discrete value you specify unless you reverse it
 
 .. code:: Ada
 
-   Values : constant array (1 .. 10) of boolean := (...);
-   
-   for I in Values'range loop
-      Put_Line ( integer'image(I) & " => " &
-                 boolean'image ( Values(I) ) );
+   Values : constant array (1 .. 10) of Boolean := (...);
+
+   for I in Values'Range loop
+      Put_Line ( Integer'Image(I) & " => " &
+                 Boolean'Image ( Values(I) ) );
    end loop;
- 
+
 ========================
 Quantified Expressions
 ========================
@@ -117,7 +117,7 @@ Semantics: As If You Wrote This Spec...
      function Existential (Collection : Set) return Boolean;
      -- True if Predicate is True for any member of Collection
    end Quantified_Expressions;
- 
+
 -----------------------------
 ...With This Implementation
 -----------------------------
@@ -135,8 +135,8 @@ Semantics: As If You Wrote This Spec...
          end loop;
          return True;
       end Universal;
-      function Existential (Collection : Set)
-         return Boolean is
+
+      function Existential (Collection : Set) return Boolean is
       begin
          for Member of Collection loop
             if Predicate (Member) then
@@ -147,7 +147,7 @@ Semantics: As If You Wrote This Spec...
          return False;
       end Existential;
    end Quantified_Expressions;
- 
+
 -------------------------------
 Quantified Expressions Syntax
 -------------------------------
@@ -156,10 +156,10 @@ Quantified Expressions Syntax
 
    quantified_expression ::=
        (for quantifier in range_specification => predicate)
-     | (for quantifier of array_expression=> predicate)
-   
+     | (for quantifier of array_expression => predicate)
+
    predicate ::= boolean_expression
-   
+
    quantifier ::= all | some
 
 .. container:: speakernote
@@ -181,7 +181,7 @@ Universal Quantifier
 
    Ultimate_Answer : constant := 42;
    Answers : constant array (1 .. 10) of Integer := ( ... );
-   
+
    All_Correct_1 : constant Boolean :=
       (for all Component of Answers =>
           Component = Ultimate_Answer);
@@ -209,14 +209,14 @@ Existential Quantifier
 
    Ultimate_Answer : constant := 42;
    Answers : constant array (1 .. 10) of Integer := ( ... );
-   
+
    Any_Correct_1 : constant Boolean :=
       (for some Component of Answers =>
           Component = Ultimate_Answer);
    Any_Correct_2 : constant Boolean :=
       (for some K in Answers'Range =>
           Answers(K) = Ultimate_Answer);
- 
+
 .. container:: speakernote
 
    Each one will "return" True
@@ -233,10 +233,10 @@ Why Index-Based Iteration Controls?
       .. code:: Ada
 
          Table : constant array (1 .. 10) of Integer := (...);
-         Ascending_Order : constant Boolean := 
-            (for all K in Table'Range => 
+         Ascending_Order : constant Boolean :=
+            (for all K in Table'Range =>
                K = Table'First or else Table (K - 1) <= Table (K));
- 
+
    - E.g., when precise control over range required
 
       .. code:: Ada
@@ -282,9 +282,9 @@ Summary
       Table : constant array (1 .. 10) of Integer :=
             (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
       Ascending_Order : constant Boolean := (
-        for all K in Table'Range => 
+        for all K in Table'Range =>
           K > Table'First and then Table (K - 1) <= Table (K));
- 
+
    - Answer: **False**. Predicate fails when `K = Table'First`
 
       + First subcondition is False!
@@ -295,4 +295,3 @@ Summary
           Ascending_Order : constant Boolean := (
              for all K in Table'Range => K = Table'first or else
                                          Table (K - 1) <= Table (K));
-


### PR DESCRIPTION
Update the SPARK course to take into account latest updates:
- foward goto is supported
- all access types are supported (including access-to-constant)
- Ada.Text_IO spec is now in SPARK