### PR TITLE
Small updates and layout fixes

### DIFF
--- a/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
+++ b/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
@@ -23,6 +23,7 @@ Verification Condition Generation
 * How are verification conditions generated?
 
    - Weakest precondition calculus
+   - Strongest postcondition calculus
 
 ---------------
 Hoare Triples
@@ -170,7 +171,7 @@ Comparison Test and Proof
 * Both techniques can be expensive
 * Industry standards
 
-   - DO-178B, DO-178C, DO-333
+   - DO-178C, DO-333
 
 * Another problem - program not all SPARK, not even all Ada - some COTS, Libraries, C, ???  What can you do?
 * How to combine?
@@ -227,13 +228,13 @@ Combining Proof and Test - Cost Benefit
 Combining Proof and Test
 --------------------------
 
-* In Ada 2012 the proof contracts are executable - they can be checked at run time and an error is raised when a check fails
+* In Ada the proof contracts are executable - they can be checked at run time and an error is raised when a check fails
 * Compilation options to support integration of test and proof
 
    - Assertion checks enabled via :command:`-gnata` compiler switch
    - Aliasing can be checked at run time with the :command:`-gnateA` switch.
    - Initialization and Validity of Data can be checked at run time with the :command:`-gnateV` and :command:`-gnatVa` switches.
-   - See the *SPARK 2014 Toolset User's Guide* for more details.
+   - See the *SPARK Toolset User's Guide* for more details.
 
 -----------------------------------------
 :toolname:`GNATprove` Tool Architecture

--- a/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
+++ b/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
@@ -260,12 +260,11 @@ Semantics of Contracts - Overflows
 
       procedure P (X, Y : in Positive; Z : out Positive)
          with Post => (if X + Y <= Positive'Last
-                          then Z = X + Y)
-                      and
-                      (if X + Y > Positive'Last
+                          then Z = X + Y
+                       else
                           then Z = Positive'Last);
 
-   - ``warning: overflow check might fail``
+   - ``medium: overflow check might fail``
 
 * Is this a false alarm in your context?
 
@@ -301,6 +300,26 @@ Overflow Checking Modes
    - 1 = strict Ada semantics for overflow checking
    - 2 = minimized overflow checking
    - 3 = eliminated - no possibility of overflow (mathematical semantics)
+
+------------------------------
+Big Integer Standard Library
+------------------------------
+
+* Overflow checking modes only applicable to expressions
+* Alternative is to use ``Ada.Numerics.Big_Numbers.Big_Integers``
+
+   - Conversions from/to signed and modular integers
+   - Specially recognized by :toolname:`GNATprove`
+
+   .. code:: Ada
+
+      function Big (Arg : Integer) return Big_Integer is
+        (To_Big_Integer (Arg)) with Ghost;
+      procedure P (X, Y : in Positive; Z : out Positive)
+         with Post => (if Big (X) + Big (Y) <= Big (Positive'Last)
+                          then Z = X + Y
+                       else
+                          then Z = Positive'Last);
 
 ========
 Lab

--- a/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
+++ b/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
@@ -192,7 +192,7 @@ Interpreting :toolname:`GNATprove` Messages
    - Example 2: returning an OUT parameter with a component uninitialized gets a *medium* rank if this occurs on all paths, and a *low* rank if this occurs only on some path.
 
 --------------------------
-Some Notes about Ranking
+Some Notes About Ranking
 --------------------------
 
 * Ranking helps the user to direct and prioritize review effort
@@ -228,7 +228,7 @@ Warning Control - Compiler Warnings
 Warning Control - SPARK Warnings
 ----------------------------------
 
-* SPARK warnings are controlled with switch warnings:
+* SPARK warnings are controlled with switch :command:`--warnings`:
 
    - :command:`--warnings=off` suppresses all warnings
    - :command:`--warnings=error` treats warnings as errors

--- a/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
+++ b/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
@@ -298,7 +298,7 @@ Loop Invariant
 
          (for all N in Integer => Prop(N) => Prop(N + 1))
 
-* Important: to be useful, the loop invariant needs to be strong enough to prove the post condition *of the loop*
+* Important: to be useful, the loop invariant needs to be strong enough to prove the postcondition *of the loop*
 
 * Loop invariant can be placed anywhere
 
@@ -327,12 +327,12 @@ Loop Invariant
 Loop Proof in :toolname:`GNATprove`
 -------------------------------------
 
-* :toolname:`GNATprove` to prove iterations around the (virtual) loop formed by the following steps:
+* :toolname:`GNATprove` considers iterations around the (virtual) loop formed by the following steps:
 
    - Take any context satisfying the loop invariant, which summarizes all previous iterations of the loop.
-   - Execute the end of a source loop iteration (just the increment here).
+   - Execute the end of a source loop iteration.
    - Test whether the loop exits, and continue with values which do not exit.
-   - Execute the start of a source loop iteration (just the if-statement here).
+   - Execute the start of a source loop iteration.
    - Check that the loop invariant still holds.
 
 .. container:: speakernote
@@ -432,7 +432,7 @@ Loop Invariants - Recipe
 * Always start with the hardest constraint...
 * ... and the easiest check!
 
-   1. Start by inspecting the post condition of the loop
+   1. Start by inspecting the postcondition of the loop
    2. Study the terminating condition of the loop
 
    3. What are the loop variables?
@@ -515,9 +515,9 @@ Summary
 * Ghost Code
 
    - Objects to maintain state information
-   - Subprogram to modularize queries and debugging steps
+   - Subprogram to modularize queries and proof steps
 
 * Loop pragmas
 
-   - Prove loop is valid for all iterations of loop
+   - Prove loop is valid for all iterations
    - Ensure loop terminates

--- a/courses/spark_for_ada_programmers/120_depends_contract_and_information_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/120_depends_contract_and_information_flow_analysis.rst
@@ -371,7 +371,7 @@ Flow Analysis Contract Computation
    - Global variable may have mode `In_Out` instead of `Output`
    - `Depends` contracts always assume that all outputs depend on all inputs.
 
-* Use :command:`--no-global-generation` for modular behavior
+* Use :command:`--no-global-generation` for fully modular behavior
 
 ---------------------------------
 Nature of Synthesized Contracts
@@ -391,7 +391,7 @@ Nature of Synthesized Contracts
 How Flow Contracts Are Synthesized
 -------------------------------------
 
-* For each contract, synthesis takes the existence of the other into account, if present
+* For each of `Global` and `Depends` contracts, synthesis takes the existence of the other into account, if present
 
   * The body content is also taken into account
 
@@ -413,7 +413,7 @@ How Flow Contracts Are Synthesized
   * No flow contracts, body does not exist
 
     - Synthesize a `Global` contract indicating no objects referenced
-    - Syntehsize a `Depends` contract indicating each output depends on all inputs
+    - Synthesize a `Depends` contract indicating each output depends on all inputs
 
 --------------------------------------
 When Only Global Contracts Specified
@@ -612,12 +612,12 @@ Summary
 
 * Global contracts
 
-   - Forces coder to specify global data interaction
+   - Forces programmer to specify global data interaction
 
 * Depends contracts
 
-   - Forces coder to specify data flow
+   - Forces programmer to specify data flow
 
-* Without these contracts, flow analysis can still be calculated
+* Without these contracts, flow analysis can still be performed
 
    - But it will be based on code as *written* as opposed to *requirements*

--- a/courses/spark_for_ada_programmers/140_interfacing_to_other_languages.rst
+++ b/courses/spark_for_ada_programmers/140_interfacing_to_other_languages.rst
@@ -284,10 +284,10 @@ Interfacing to C - Build Foundation
 
       .. code:: Ada
 
-         function Is_SHA_1 (Data : Buffer_Type;
+         function Is_SHA_1 (Data   : Buffer_Type;
                             Result : Result_Type)
                             return Boolean
-            with Convention => Ghost;
+            with Ghost;
 
 ----------------------------------
 Interfacing to C - Build Wrapper
@@ -299,9 +299,9 @@ Interfacing to C - Build Wrapper
 
       .. code:: Ada
 
-         procedure SHA_1 (Data : in Buffer_Type;
+         procedure SHA_1 (Data   : in Buffer_Type;
                           Result : out Result_Type;
-                          Error : out Error_Code)
+                          Error  : out Error_Code)
             with Global => null,
                  Post => (if Error = 0 then Is_SHA_1(Data,Result));
 
@@ -332,13 +332,13 @@ Interfacing to C - Result
 
    -- Internal_SHA_1 has a side-effect - an out parameter -
    -- which corresponds to the C function sha_1
-   procedure SHA_1 (Data : in Buffer_Type;
+   procedure SHA_1 (Data   : in Buffer_Type;
                     Result : out Result_Type;
-                    Error : out Error_Code)
+                    Error  : out Error_Code)
       -- The body of procedure SHA_1 is not in SPARK
       with SPARK_Mode => Off is
-      function Internal_SHA_1 ( Data : in Buffer_Type;
-                                Result : out Result_Type)
+      function Internal_SHA_1 (Data   : in Buffer_Type;
+                               Result : out Result_Type)
             -- Result type of Int rather than Error_Code to
             -- avoid possibility of invalid values
             return Int

--- a/courses/spark_for_ada_programmers/150_crossing_the_spark_boundary.rst
+++ b/courses/spark_for_ada_programmers/150_crossing_the_spark_boundary.rst
@@ -46,8 +46,8 @@ SPARK Mode
 
       .. code:: Ada
 
-         pragma SPARK_Mode (On); -- equivalent to SPARK_Mode => On
-         pragma SPARK_Mode (Off); -- equivalent to SPARK_Mode => Off
+         pragma SPARK_Mode (On); -- same as SPARK_Mode => On
+         pragma SPARK_Mode (Off); -- same as SPARK_Mode => Off
 
 --------------------------
 `SPARK_Mode` Not Present
@@ -61,8 +61,7 @@ SPARK Mode
       .. code:: Ada
 
          package No_SPARK_Mode is
-           type T is range 0.. 100;
-           type Access_T is access T; -- Not allowed in SPARK
+           type T is range 0.. 100; -- Allowed in SPARK
          end No_SPARK_Mode;
 
    - This unit's declarations can be denoted in SPARK code provided they are SPARK compatible, but use declarations of subprograms with caution - they may have globals which are not apparent
@@ -87,8 +86,7 @@ SPARK Mode
       .. code:: Ada
 
          package SPARK_Mode_Off with SPARK_Mode => Off is
-         type T is range 0.. 100;
-         type Access_T is access T;
+            type T is range 0.. 100;
          end SPARK_Mode_Off;
 
    - If we try to use this unit we get errors
@@ -132,10 +130,10 @@ What Can It Apply To?
 
    - A unit specification (declaration)
    - A unit body
-   - A private part of a package (`pragma SPARK_Mode` must used here)
-   - The sequence of statements of a package body (`pragma SPARK_Mode` must used here)
+   - A private part of a package (using `pragma SPARK_Mode`)
+   - The sequence of statements of a package body (using `pragma SPARK_Mode`)
 
-* `SPARK_Mode` is a also a configuration pragma
+* `SPARK_Mode` is also a configuration pragma
 
    - This means it can be placed in a configuration file and apply to all compilation units
 
@@ -143,7 +141,8 @@ What Can It Apply To?
 Where Can It Be Placed?
 -------------------------
 
-* `SPARK_Mode` can only be placed at library-level
+* `SPARK_Mode => On` can only be placed at library level
+* `SPARK_Mode => Off` can also be used for local subprograms/packages
 * If `pragma SPARK_Mode` is used rather than aspect for a unit
 
    - It is placed before any context clause, or,
@@ -188,7 +187,7 @@ Summary
 
 * Our entire project cannot be SPARK
 
-   + At least not yet!
+   + At least not always!
    + Interactions with the outside world can't always conform to the necessary requirements
 
 * How do we use SPARK as much as possible?

--- a/courses/spark_for_ada_programmers/160_interfacing.rst
+++ b/courses/spark_for_ada_programmers/160_interfacing.rst
@@ -64,8 +64,8 @@ Monitored and Controlled Variable Examples
 
          procedure Monitored_And_Controlled_Issues with
             SPARK_Mode,
-            Global => (Input => Monitored_Var,
-            Output => Controlled_Var)
+            Global => (Input  => Monitored_Var,
+                       Output => Controlled_Var)
          is
          begin
             -- Assertion may fail because successive reads of a

--- a/courses/spark_for_ada_programmers/170_designing_for_spark.rst
+++ b/courses/spark_for_ada_programmers/170_designing_for_spark.rst
@@ -26,7 +26,7 @@ Architecture
 ==============
 
 ----------------------------
-Choice Of Architecture
+Choice of Architecture
 ----------------------------
 
 * The choice of architecture is vitally important in determining the following properties of a program:
@@ -38,7 +38,7 @@ Choice Of Architecture
    - Stability
 
 ----------------------------
-Importance Of Architecture
+Importance of Architecture
 ----------------------------
 
 * Of particular importance are
@@ -458,7 +458,7 @@ Moving State Outside SPARK Boundary
    with System.Storage_Elements;
    package body Test_Points with
      SPARK_Mode,
-     Refined_State =>  (The_Point => Test_Point)
+     Refined_State => (The_Point => Test_Point)
    is
       Test_Point : Long_Integer with
         Volatile,
@@ -477,7 +477,7 @@ Moving State Outside SPARK Boundary
 
 .. code:: Ada
 
-   procedure To_Test_Point (Val : Long_Integer) with
+      procedure To_Test_Point (Val : Long_Integer) with
         Global => (Output => Test_Point)
       is
       begin
@@ -501,12 +501,12 @@ Moving State Outside SPARK Boundary
 
 .. code:: Ada
 
-   procedure Copy (Val : Long_Integer) with
-        SPARK_Mode => On
-    is
-    begin
-       null;
-    end Copy;
+      procedure Copy (Val : Long_Integer) with
+         SPARK_Mode => On
+      is
+      begin
+         null;
+      end Copy;
    end Test_Points;
 
 -----------------

--- a/courses/spark_for_ada_programmers/180_adoption_guidance.rst
+++ b/courses/spark_for_ada_programmers/180_adoption_guidance.rst
@@ -166,14 +166,14 @@ Stone Level Code Changes
 
    - E.g., change functions with side-effects into procedures
 
-* Hide use of pointers
+* Hide unsupported use of pointers (e.g. doubly linked list)
 
    - Within package bodies
    - Dereferences changed to function calls
    - Probably the most extensive effort
-   - Where pointers remain, turn off `SPARK_Mode`
+   - Where unsupported pointers remain, turn off `SPARK_Mode`
 
-* Et cetera
+* Etc.
 * See the Adoption Guide for how to make changes
 
    - Extensive examples provided!

--- a/courses/spark_for_ada_programmers/990_spark_example_project.rst
+++ b/courses/spark_for_ada_programmers/990_spark_example_project.rst
@@ -45,13 +45,13 @@ Demonstrating What You Have Learned
 
    - You can accept the flow errors with an appropriate justification
 
-   - Correct the code if  necessary 
+   - Correct the code if necessary
 
 * Add postconditions as complete as possible and prove them
 
    -  You can reformulate the code to make it easier to prove
 
-* To prove `Insert`, `Overwrite`, and `Head`:
+* To prove `Insert`, `Overwrite`, and `Head` :
 
    - Assume that `Source` and `New_Item` start at 1.
 

--- a/courses/spark_for_ada_programmers/labs/060_contracts.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/060_contracts.lab.rst
@@ -10,7 +10,7 @@ Contracts Lab
 
    + Or, on the command-line, do :command:`gnatstudio -Pdefault.gpr`
 
-- Unfold the source code directory (.) in the project pane 
+- Unfold the source code directory (.) in the project pane
 
 .. container:: speakernote
 
@@ -23,9 +23,9 @@ Longest Common Prefix
 
 * Requirements
 
- - Given a global array A containing integers
- - Given two integers X and Y, indices of A
- - Return the length of the longest common prefix of the two sub-arrays starting at X and Y.
+   + Given a global array A containing integers
+   + Given two integers X and Y, indices of A
+   + Return the length of the longest common prefix of the two sub-arrays starting at X and Y.
 
 * Example
 
@@ -44,7 +44,7 @@ Longest Common Prefix
       - 9
       - 2
 
-* ``|{|X = 2, Y = 6|}| => R = 4``
+* ``{X = 2, Y = 6} => R = 4``
 
 --------------------
 Lab Tasks Overview

--- a/courses/spark_for_ada_programmers/labs/090_proving_absence_of_run_time_errors.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/090_proving_absence_of_run_time_errors.lab.rst
@@ -53,7 +53,7 @@ Run-Time Exception Freedom Proof (cont)
 
    + There is an implicit precondition, what is it?
    + Square of longest side is in the range of `Natural`
-   + Sum of the squares of the other two sides is in the range of` Natural`
+   + Sum of the squares of the other two sides is in the range of `Natural`
 
 * Rebuild and re-run.
 

--- a/courses/spark_for_ada_programmers/labs/130_state_abstraction.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/130_state_abstraction.lab.rst
@@ -48,9 +48,9 @@ Global Data
 
    + No errors because data flow specified via global contracts
 
-      * Actual global objects are used in the contracts (Actual names `SP` and `Vec`)
+      * Actual global objects are used in the contracts (Actual names `Sp` and `Vec`)
 
-      * Even `Reverser` uses the global objects in its contracts
+      * Even `Reverser` uses the global objects in its contract
 
 - Imagine how much more complicated this would be with more global data
 
@@ -83,14 +83,14 @@ Refining a State
 
       * Specify constituents of the state abstraction `The_Stack`.
 
-- Subprograms previously declared with `Abstract_State` need to add `Refined_State` to their implementation
+- Subprograms previously declared with `Abstract_State` may add `Refined_State` to their implementation
 
    * Specify global data being referenced
 
 - Lots of "extra work" to add this information
 
    + Only affects body of implementation
-   + Saves work later
+   + If not provided by the user, computed by the tool
 
 - :menu:`Prove` (or :menu:`Examine`) the packages
 
@@ -100,7 +100,7 @@ Refining a State
 Adding a Utilization Function
 -------------------------------
 
-+ Add a function `Utilization` to return a `natural` which gives maximum depth of `The_Stack` used so far.
++ Add a function `Utilization` to return a `Natural` which gives maximum depth of `The_Stack` used so far.
 
    * Has to be declared in specification of `A_Stack`
 

--- a/courses/spark_for_ada_programmers/labs/150_crossing_the_spark_boundary.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/150_crossing_the_spark_boundary.lab.rst
@@ -2,7 +2,7 @@
 Crossing the SPARK Boundary Lab
 ---------------------------------
 
-- Find the :filename:`140_crossing_the_spark_boundary` sub-directory in :filename:`source`
+- Find the :filename:`150_crossing_the_spark_boundary` sub-directory in :filename:`source`
 
    + You can copy it locally, or work with it in-place
 

--- a/courses/spark_for_ada_programmers/labs/160_interfacing.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/160_interfacing.lab.rst
@@ -2,7 +2,7 @@
 Interfacing Lab
 -----------------
 
-- Find the :filename:`150_interfacing` sub-directory in :filename:`source`
+- Find the :filename:`160_interfacing` sub-directory in :filename:`source`
 
    + You can copy it locally, or work with it in-place
 

--- a/courses/spark_for_ada_programmers/labs/answers/070_type_contracts/important_dates.adb
+++ b/courses/spark_for_ada_programmers/labs/answers/070_type_contracts/important_dates.adb
@@ -11,51 +11,21 @@ is
 
    function ">="
      (L, R : Date_T)
-      return Boolean is
-      Ret_Val : Boolean := False;
-   begin
-      if L.Year > R.Year
-      then
-         Ret_Val := True;
-      elsif L.Year = R.Year
-      then
-         if L.Month > R.Month
-         then
-            Ret_Val := True;
-         elsif L.Month = R.Month
-         then
-            if L.Day > R.Day
-            then
-               Ret_Val := True;
-            elsif L.Day = R.Day
-            then
-               Ret_Val := True;
-            end if;
-         end if;
-      end if;
-      return Ret_Val;
-   end ">=";
+      return Boolean
+   is
+      (L.Year > R.Year
+       or else
+         (L.Year = R.Year
+          and then
+            (L.Month > R.Month
+             or else (L.Month = R.Month
+               and then L.Day >= R.Day))));
 
    function ">="
      (L, R : Event_T)
-      return Boolean is
-      Ret_Val : Boolean := False;
-   begin
-      if L.Date >= R.Date
-      then
-         Ret_Val := True;
-      elsif L.Date = R.Date
-      then
-         if L.Description > R.Description
-         then
-            Ret_Val := True;
-         elsif L.Description = R.Description
-         then
-            Ret_Val := True;
-         end if;
-      end if;
-      return Ret_Val;
-   end ">=";
+      return Boolean
+   is
+      (L.Date >= R.Date);
 
    ---------------
    -- Add_Event --
@@ -82,14 +52,26 @@ is
                then
                   Calendar.List
                     (K + 1 .. Last + 1) := Calendar.List (K .. Last);
+                  pragma Assert (K = First or else not (Calendar.List (K - 1) >= Event));
+                  pragma Assert (K = First or else Event >= Calendar.List (K - 1));
+                  pragma Assert (Calendar.List (K + 1) >= Event);
                   Calendar.List (K)     := Event;
                   Added                 := True;
+                  pragma Assert
+                    (for all J in First .. Last + 1 =>
+                       J = First or else Calendar.List (J) >= Calendar.List (J - 1));
                   exit;
                end if;
+               pragma Loop_Invariant
+                 (for all J in First .. K => not (Calendar.List (J) >= Event));
             end loop;
             if not Added
             then
+               pragma Assert (Event >= Calendar.List (Last));
                Calendar.List (Last + 1) := Event;
+               pragma Assert
+                 (for all J in First .. Last + 1 =>
+                    J = First or else Calendar.List (J) >= Calendar.List (J - 1));
             end if;
          end;
       end if;
@@ -113,9 +95,14 @@ is
       loop
          if Calendar.List (K) = Event
          then
-            Calendar.List
-              (K .. Last - 1) := Calendar.List
-                (K + 1 .. Last);
+            pragma Assert
+              (K = First
+               or else K = Last
+               or else Calendar.List (K + 1) >= Calendar.List (K - 1));
+            Calendar.List (K .. Last - 1) := Calendar.List (K + 1 .. Last);
+            pragma Assert
+              (for all J in First .. Last - 1 =>
+                 J = First or else Calendar.List (J) >= Calendar.List (J - 1));
             Calendar.In_Use := Calendar.In_Use - 1;
             exit;
          end if;
@@ -140,8 +127,9 @@ is
       loop
          if Calendar.List (K).Date >= Date
          then
-            for J in K .. Integer'Min (Last, K + Number_Of_Events - 1)
+            for J in K .. Last
             loop
+               exit when J - K + 1 > Number_Of_Events;
                Put
                  (Calendar.List (J).Date.Year'Image & "-" &
                   Calendar.List (J).Date.Month'Image & "-" &

--- a/courses/spark_for_ada_programmers/labs/answers/070_type_contracts/important_dates.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/070_type_contracts/important_dates.ads
@@ -60,18 +60,19 @@ private
      (L, R : Event_T)
       return Boolean;
 
+   subtype Count_T is Integer range 0 .. 1_000;
    subtype Index_T is Integer range 1 .. 1_000;
    type Event_List_T is array (Index_T) of Event_T;
    function Is_Sorted
      (List : Event_List_T;
-      Used : Integer)
+      Used : Count_T)
       return Boolean is
      (for all K in List'First .. List'First + Used - 1 =>
         K = List'First or else List (K) >= List (K - 1));
 
    type Calendar_T is record
       List   : Event_List_T;
-      In_Use : Integer := 0;
+      In_Use : Count_T := 0;
    end record with
       Type_Invariant => Is_Sorted (Calendar_T.List, Calendar_T.In_Use);
 

--- a/courses/spark_for_ada_programmers/labs/answers/090_proving_absence_of_run_time_errors/main.adb
+++ b/courses/spark_for_ada_programmers/labs/answers/090_proving_absence_of_run_time_errors/main.adb
@@ -11,20 +11,15 @@ is
    --  (Note that the function could have been implemented as a simple
    --  expression function.)
 
-   function valid_length ( side : natural ) return boolean is
- --     ( side > 0 and then side <= natural'last / side );
-      ( side > 0 and then side <= natural'last / side );
-
    function Is_Right_Angle_Triangle (Long_Side : Natural;
                                      Side_2    : Natural;
                                      Side_3    : Natural) return Boolean
      with
---       with pre => ( valid_length ( long_side ) and then
---       valid_length ( side_2 ) and then
---       valid_length ( side_3 ) ),
+       Pre  => Long_Side * Long_Side in Natural
+         and then (Side_2 * Side_2) + (Side_3 * Side_3) in Natural,
        Post => (if Long_Side * Long_Side =
                      (Side_2 * Side_2) + (Side_3 * Side_3)
-                   then Is_Right_Angle_Triangle'Result = True)
+                then Is_Right_Angle_Triangle'Result = True)
    is
    begin
       -- Note that this function has multiple return statements. In SPARK 2005

--- a/courses/spark_for_ada_programmers/labs/answers/110_advanced_proof_techniques/max.adb
+++ b/courses/spark_for_ada_programmers/labs/answers/110_advanced_proof_techniques/max.adb
@@ -1,4 +1,6 @@
-package body Max is
+package body Max
+  with SPARK_Mode
+is
 
    function Arrays_Max (A : in Our_Array) return Index_Range is
       X : Index_Range := Index_Range'First;

--- a/courses/spark_for_ada_programmers/labs/answers/110_advanced_proof_techniques/max.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/110_advanced_proof_techniques/max.ads
@@ -1,4 +1,6 @@
-package Max is
+package Max
+  with SPARK_Mode
+is
 
    Min_Table_Size : constant := 1;
    Max_Table_Size : constant := 100;

--- a/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/array_swapping.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/array_swapping.ads
@@ -11,8 +11,8 @@ is
        Pre     => X /= Y and
                   Y /= Z and
                   X /= Z,
-       Post    => A = A'Old'Update (X => A'Old(Y),
-                                    Y => A'Old(Z),
-                                    Z => A'Old(X));
+       Post    => A = (A'Old with delta X => A'Old(Y),
+                                        Y => A'Old(Z),
+                                        Z => A'Old(X));
 
 end Array_Swapping;

--- a/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/default.gpr
+++ b/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/default.gpr
@@ -1,7 +1,11 @@
 project Default is
 
+   package Builder is
+      for Global_Configuration_Pragmas use "config_pragmas.adc";
+   end Builder;
+
    package Compiler is
-      for Default_Switches ("ada") use ("-g", "-gnata", "-gnato13");
+      for Default_Switches ("ada") use ("-g", "-gnata", "-gnato13", "-gnat2020");
    end Compiler;
 
    package Prove is
@@ -9,4 +13,3 @@ project Default is
    end Prove;
 
 end Default;
-

--- a/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/depends_exercise.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/120_depends_contract_and_information_flow_analysis/depends_exercise.ads
@@ -13,11 +13,10 @@ package Depends_Exercise is
    Depends => (stack_pointer=>null, stack=>null);
       
    -- Add suitable Global and Depends contracts
-      procedure Push (X : in Integer) with
+   procedure Push (X : in Integer) with
      Global => ( input => null,
-                 in_out => stack_pointer,
-                 output => stack),  
-     Depends => (stack_pointer=>stack_pointer, stack=>(stack_pointer,x));
+                 in_out => (stack_pointer, stack)),  
+     Depends => (stack_pointer=>stack_pointer, stack=>+(stack_pointer,x));
    
    -- Add suitable Global and Depends contracts
    -- Why might it be useful to put a Depends contract on a function?

--- a/courses/spark_for_ada_programmers/labs/answers/130_state_abstractions/refined/a_stack.adb
+++ b/courses/spark_for_ada_programmers/labs/answers/130_state_abstractions/refined/a_stack.adb
@@ -1,6 +1,6 @@
 package body A_Stack with
    SPARK_Mode,
-   --  The_Stack is actually refined into two constituents
+   --  The_Stack is actually refined into three constituents
    Refined_State => (The_Stack => (P, V, M))
 is
 
@@ -17,9 +17,9 @@ is
    function Top return Item is (V (P)) with
       Refined_Global => (P, V);
 
-      ----------
-      -- Push --
-      ----------
+   ----------
+   -- Push --
+   ----------
 
    procedure Push (It : in Item) with
       Refined_Global => (In_Out => (P, V, M))

--- a/courses/spark_for_ada_programmers/labs/answers/150_crossing_the_spark_boundary/crypto.adb
+++ b/courses/spark_for_ada_programmers/labs/answers/150_crossing_the_spark_boundary/crypto.adb
@@ -6,22 +6,22 @@ package body Crypto with
    Refined_State => (key_store => null)
 is
 
-   --------------
-   -- load_key --
-   --------------
+   -------------
+   -- loadkey --
+   -------------
 
-   procedure load_key
-     (keyslot : in Key_Slot; the_key : in Key; result : out Boolean) with
-      SPARK_Mode => off
+   procedure loadkey
+     (keyslot : in Key_Slot; the_key : in Key; result : out Boolean)
    is
       function c_loadkey
         (keyslot : Key_Slot; the_key : Key) return Interfaces.C.int with
          Import,
          Convention    => c,
-         External_Name => "loadkey";
+         External_Name => "loadkey",
+         Global        => null;
    begin
       result := c_loadkey (keyslot, the_key) = 0;
-   end load_key;
+   end loadkey;
 
    -------------
    -- encrypt --
@@ -32,8 +32,7 @@ is
       SPARK_Mode => off
    is
       function c_encrypt
-        (keyslot : Key_Slot; the_data : in out Data) return Interfaces.C
-        .int with
+        (keyslot : Key_Slot; the_data : in out Data) return Interfaces.C.int with
          Import,
          Convention    => c,
          External_Name => "encrypt";

--- a/courses/spark_for_ada_programmers/labs/answers/150_crossing_the_spark_boundary/crypto.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/150_crossing_the_spark_boundary/crypto.ads
@@ -13,7 +13,7 @@ is
    type Data_Index is range 1 .. 1_024;
    type Data is array (Data_Index) of Byte;
 
-   procedure load_key
+   procedure loadkey
      (keyslot : in Key_Slot; the_key : in Key; result : out Boolean) with
       Global => (in_out => key_store);
 

--- a/courses/spark_for_ada_programmers/labs/answers/160_interfacing/counter.ads
+++ b/courses/spark_for_ada_programmers/labs/answers/160_interfacing/counter.ads
@@ -16,7 +16,7 @@ is
    Port : Integer with volatile,
      async_writers,
      effective_reads,
-       address => system.storage_elements.to_address ( 16#1234ABCD# );
+     address => system.storage_elements.to_address ( 16#1234ABCD# );
 
    Limit : constant Integer := 3_000_000;
 

--- a/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/aliasing.adb
+++ b/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/aliasing.adb
@@ -5,7 +5,7 @@ package body Aliasing
 is
 
    procedure Multiply (X, Y : in     Rec;
-		       Z    :    out Rec)
+                       Z    :    out Rec)
    is
    begin
       Z := (0, 0);
@@ -21,9 +21,8 @@ is
       R := (10, 10);
       Result := 100;
 
-      -- If R is passed by reference, then
-      -- parameters might be aliased here. This is Unspecified
-      -- in Ada 2012, so must be eliminated in SPARK
+      -- If R is passed by reference, then parameters might be aliased here.
+      -- This is unspecified in Ada, so must be eliminated in SPARK
       Multiply (R, R, R);
 
       Result := Result / R.F; -- So R.F might be 0 here

--- a/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/side_effects.adb
+++ b/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/side_effects.adb
@@ -18,9 +18,9 @@ is
       Z := 10;
 
       R := Y / Z + F (X); -- possible order dependency here.
-
-      Simple_IO.Put_Line (R);  -- R = 13 if L->R evaluation,
-			       -- constraint error if R->L
+                          -- R = 13 if L->R evaluation,
+                          -- constraint error if R->L evaluation
+      Simple_IO.Put_Line (R);
    end Test;
 
 end Side_Effects;

--- a/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/subset.ads
+++ b/courses/spark_for_ada_programmers/labs/source/030_spark_language_and_tools/subset.ads
@@ -1,34 +1,22 @@
+with Ada.Unchecked_Conversion;
+with System;
+
 package Subset
   with SPARK_Mode => On
 is
-   -- SPARK 2014 Tutorial - Exercise 1
-   
-   -- A few simple example of language constructs that currently
-   -- violate the SPARK 2014 subset.
+   -- A few simple example of language constructs that currently violate the
+   -- SPARK subset.
 
-
-   -- Access type
+   -- Unchecked conversion with access type is not allowed in SPARK
    type T is access Integer;
-
-   -- SPARK 2014 now permits record types with partial default
-   -- values (initialisation checked per record field)
-   type R is record
-      F1 : Integer := 0;
-      F2 : Boolean;
+   function Conv is new Ada.Unchecked_Conversion (System.Address, T);
+   
+   -- Access discriminant is not allowed in SPARK
+   type R2 (D : access Boolean) is record
+      F1 : Integer;
    end record;
    
-   -- Discriminated and variant records are allowed in SPARK 2014...
-   type R2 (D : Boolean) is record
-      F1 : Integer;
-      case D is
-	 when False =>
-	    F2 : Character;
-	 when True =>
-	    F3 : Float;
-      end case;
-   end record with Unchecked_Union; -- and Unchecked_Union (statically checked).
-   
-   -- Task type are not currently permitted.
+   -- Task requires the use of Ravenscar profile
    task type My_Task;
    
 end Subset;

--- a/courses/spark_for_ada_programmers/labs/source/040_data_flow_analysis/dfa.adb
+++ b/courses/spark_for_ada_programmers/labs/source/040_data_flow_analysis/dfa.adb
@@ -6,9 +6,8 @@ is
    is
       Tmp : Integer;
    begin
-      -- The most basic form of DFA bug - Tmp is definitely
-      -- not initialized. We call this an Unconditional
-      -- Data Flow Error
+      -- The most basic form of DFA bug - Tmp is definitely not initialized. We
+      -- call this an Unconditional Data Flow Error
       return X + Tmp;
    end F1;
 
@@ -25,11 +24,10 @@ is
 	    Tmp := 1;
       end case;
       
-      -- Slightly more subtle - Tmp _might_ not be
-      -- initialized, depending on the initial value of X.
-      -- We call this a Conditional Data Flow Error.
-      -- Note that the error message issued here is different
-      -- from that issued in F1 above.
+      -- Slightly more subtle - Tmp _might_ not be initialized, depending on
+      -- the initial value of X. We call this a Conditional Data Flow Error.
+      -- Note that the error message issued here is different from that issued
+      -- in F1 above.
       return X + Tmp;
    end F2;
    

--- a/courses/spark_for_ada_programmers/labs/source/040_data_flow_analysis/dfa.ads
+++ b/courses/spark_for_ada_programmers/labs/source/040_data_flow_analysis/dfa.ads
@@ -1,10 +1,7 @@
 package DFA
   with SPARK_Mode => On
 is
-   -- SPARK 2014 Tutorial
-   
-   -- This package illustrates the basics of data-flow analysis (DFA)
-   -- in SPARK.
+   -- This package illustrates the basics of data-flow analysis (DFA) in SPARK
    
    function F1 (X : in Integer) return Integer;
 

--- a/courses/spark_for_ada_programmers/labs/source/090_proving_absence_of_run_time_errors/default.gpr
+++ b/courses/spark_for_ada_programmers/labs/source/090_proving_absence_of_run_time_errors/default.gpr
@@ -1,7 +1,7 @@
 project Default is
 
    package Compiler is
-      for Default_Switches ("ada") use ("-g", "-gnata", "-gnato13");
+      for Default_Switches ("ada") use ("-g");
    end Compiler;
 
    package Prove is
@@ -11,4 +11,3 @@ project Default is
    for Main use ("main.adb");
 
 end Default;
-

--- a/courses/spark_for_ada_programmers/labs/source/110_advanced_proof_techniques/max.adb
+++ b/courses/spark_for_ada_programmers/labs/source/110_advanced_proof_techniques/max.adb
@@ -1,4 +1,6 @@
-package body Max is
+package body Max
+  with SPARK_Mode
+is
 
    function Arrays_Max (A : in Our_Array) return Index_Range is
       X : Index_Range := Index_Range'First;

--- a/courses/spark_for_ada_programmers/labs/source/110_advanced_proof_techniques/max.ads
+++ b/courses/spark_for_ada_programmers/labs/source/110_advanced_proof_techniques/max.ads
@@ -1,4 +1,6 @@
-package Max is
+package Max
+  with SPARK_Mode
+is
 
    Min_Table_Size : constant := 1;
    Max_Table_Size : constant := 100;

--- a/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/array_swapping.ads
+++ b/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/array_swapping.ads
@@ -11,8 +11,8 @@ is
        Pre     => X /= Y and
                   Y /= Z and
                   X /= Z,
-       Post    => A = A'Old'Update (X => A'Old(Y),
-                                    Y => A'Old(Z),
-                                    Z => A'Old(X));
+       Post    => A = (A'Old with delta X => A'Old(Y),
+                                        Y => A'Old(Z),
+                                        Z => A'Old(X));
 
 end Array_Swapping;

--- a/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/default.gpr
+++ b/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/default.gpr
@@ -1,7 +1,11 @@
 project Default is
 
+   package Builder is
+      for Global_Configuration_Pragmas use "config_pragmas.adc";
+   end Builder;
+
    package Compiler is
-      for Default_Switches ("ada") use ("-g", "-gnata", "-gnato13");
+      for Default_Switches ("ada") use ("-g", "-gnata", "-gnato13", "-gnat2020");
    end Compiler;
 
    package Prove is
@@ -9,4 +13,3 @@ project Default is
    end Prove;
 
 end Default;
-

--- a/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/depends_exercise.ads
+++ b/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/depends_exercise.ads
@@ -10,7 +10,7 @@ package Depends_Exercise is
    procedure Initialize;
       
    -- Add suitable Global and Depends contracts
-      procedure Push (X : in Integer);
+   procedure Push (X : in Integer);
    
    -- Add suitable Global and Depends contracts
    -- Why might it be useful to put a Depends contract on a function?

--- a/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/swapping.ads
+++ b/courses/spark_for_ada_programmers/labs/source/120_depends_contract_and_information_flow_analysis/swapping.ads
@@ -1,9 +1,7 @@
 package Swapping
 is
 
-   procedure Swap (X, Y: in out Positive)
-     with Depends => (X => Y,
-                      Y => X);
+   procedure Swap (X, Y: in out Positive);
 
    procedure Identity (X, Y: in out Positive)
      with Depends => (X => X,


### PR DESCRIPTION
- change references to 'Update for delta aggregates
- always put Type_Invariant on the type completion in SPARK
- mention use of Big_Integers standard library
- remove references to accesses as not in SPARK
- add that SPARK_Mode Off can be used inside subprograms