### PR TITLE
remove relative image path

### DIFF
--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -190,7 +190,7 @@ The Type Model Saves Money
 
     - Cost of an error *during a flight*?
 
-.. image:: ../../images/relative_cost_to_fix.png
+.. image:: relative_cost_to_fix.png
    :height: 50%
 
 ---------------------------
@@ -361,7 +361,7 @@ Generic Units
 
  .. container:: column
 
-    .. image:: ../../images/generic_template_to_instances.png
+    .. image:: generic_template_to_instances.png
 
 -------------------
 Stack with Generics
@@ -566,7 +566,7 @@ So Why Isn't Ada Used Everywhere?
 
  .. container:: column
 
-    .. image:: ../../images/mark_twain.jpeg
+    .. image:: mark_twain.jpeg
 
 =======
 Setup

--- a/courses/fundamentals_of_ada/020_declarations.rst
+++ b/courses/fundamentals_of_ada/020_declarations.rst
@@ -18,7 +18,7 @@ Introduction
 Identifiers
 ---------------------
 
-.. image:: ../../images/identifier_flow.png
+.. image:: identifier_flow.png
    :width: 60%
 
 .. container:: columns
@@ -653,7 +653,7 @@ Scope and "Lifetime"
 
     - C's :c:`static`, :c:`auto` etc...
 
-.. image:: ../../images/block_scope_example.jpeg
+.. image:: block_scope_example.jpeg
     :height: 50%
 
 -------------

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -89,7 +89,7 @@ Ada "Named Typing"
 Categories of Types
 ---------------------
 
-.. image:: ../../images/types_tree.png
+.. image:: types_tree.png
 
 --------------
 Scalar Types
@@ -888,7 +888,7 @@ Why Boolean Isn't Just An Integer?
 
  .. container:: column
 
-    .. image:: ../../images/hete-2_satellite.jpeg
+    .. image:: hete-2_satellite.jpeg
 
 ------------------------------------
 Why Boolean Isn't Just An Integer!

--- a/courses/fundamentals_of_ada/100_packages.rst
+++ b/courses/fundamentals_of_ada/100_packages.rst
@@ -568,7 +568,7 @@ Uncontrolled Data Visibility Problem
 
  .. container:: column
 
-    .. image:: ../../images/subprograms_accessing_global.png
+    .. image:: subprograms_accessing_global.png
 
 --------------------------------------------
 Controlling Data Visibility Using Packages
@@ -585,7 +585,7 @@ Controlling Data Visibility Using Packages
 
 |
 
-.. image:: ../../images/packages_hiding_global_data.png
+.. image:: packages_hiding_global_data.png
    :width: 85%
 
 ------------------------

--- a/courses/fundamentals_of_ada/110_private_types.rst
+++ b/courses/fundamentals_of_ada/110_private_types.rst
@@ -43,7 +43,7 @@ Information Hiding
 
  .. container:: column
 
-    .. image:: ../../images/interface_vs_implementation.png
+    .. image:: interface_vs_implementation.png
        :width: 70%
 
 -------

--- a/courses/fundamentals_of_ada/130_program_structure.rst
+++ b/courses/fundamentals_of_ada/130_program_structure.rst
@@ -72,7 +72,7 @@ Handling Cyclic Dependencies
 
 * Which package elaborates first?
 
-.. image:: ../../images/cyclic_dependencies.png
+.. image:: cyclic_dependencies.png
    :width: 50%
    :align: center
 
@@ -83,7 +83,7 @@ Body-Level Cross Dependencies Are OK
 * The bodies only depend on other packages' declarations
 * The declarations are already elaborated by the time the bodies are elaborated
 
-.. image:: ../../images/mutual_dependencies.png
+.. image:: mutual_dependencies.png
    :width: 70%
    :align: center
 
@@ -299,7 +299,7 @@ Solution: Hierarchical Library Units
 
  .. container:: column
 
-    .. image:: ../../images/hierarchical_library_units.png
+    .. image:: hierarchical_library_units.png
 
 --------------------------
 Programming By Extension
@@ -426,7 +426,7 @@ Hierarchical Visibility
 
  .. container:: column
 
-    .. image:: ../../images/hierarchical_visibility.png
+    .. image:: hierarchical_visibility.png
 
 ------------------------------------
 Example of Visibility As If Nested

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -70,7 +70,7 @@ Stack vs Heap
   I : Integer := 0;
   J : String := "Some Long String";
 
-.. image:: ../../images/items_on_stack.png
+.. image:: items_on_stack.png
    :width: 50%
 
 .. code:: Ada
@@ -78,7 +78,7 @@ Stack vs Heap
   I : Access_Int:= new Integer'(0);
   J : Access_Str := new String ("Some Long String");
 
-.. image:: ../../images/stack_pointing_to_heap.png
+.. image:: stack_pointing_to_heap.png
    :width: 50%
 
 ==========================

--- a/courses/fundamentals_of_ada/190_exceptions.rst
+++ b/courses/fundamentals_of_ada/190_exceptions.rst
@@ -839,7 +839,7 @@ Exceptions Are Not Always Appropriate
 
  .. container:: column
 
-    .. image:: ../../images/airbag_exception_handler.png
+    .. image:: airbag_exception_handler.png
 
 ---------------------------------------
 Relying On Exception Raising Is Risky

--- a/courses/fundamentals_of_ada/920_reference_material.rst
+++ b/courses/fundamentals_of_ada/920_reference_material.rst
@@ -13,7 +13,7 @@ Learning the Ada Language
 
 * Written as a tutorial for those new to Ada
 
-.. image:: ../../images/barnes_2012_cover.png
+.. image:: barnes_2012_cover.png
 
 ------------------
 Reference Manual
@@ -50,7 +50,7 @@ Reference Manual
 
 * Reference Manual(s) available from :toolname:`GNAT Studio` Help
 
-.. image:: ../../images/gnatstudio-help-gnat.jpeg
+.. image:: gnatstudio-help-gnat.jpeg
 
 -------------
 GNAT Tools

--- a/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
@@ -256,7 +256,7 @@ Ceiling Locking
 
 |
 
-.. image:: ../../images/ravenscar_ceiling_locking.png
+.. image:: ravenscar_ceiling_locking.png
    :width: 45%
 
  .. container:: column

--- a/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
@@ -177,7 +177,7 @@ Pre/Postcondition Semantics
 
 |
 
-.. image:: ../../images/pre_and_post_insertion_flow.png
+.. image:: pre_and_post_insertion_flow.png
    :width: 90%
 
 -----------------------------

--- a/courses/fundamentals_of_ada/adv_275_type_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_275_type_contracts.rst
@@ -91,13 +91,13 @@ Type Invariant Verifications
 
 * Remember - these are abstract data types
 
-.. image:: ../../images/black_box_flow.png
+.. image:: black_box_flow.png
 
 ----------------------------------------
 Invariant Over Object Lifetime (Calls)
 ----------------------------------------
 
-.. image:: ../../images/type_invariant_check_flow.png
+.. image:: type_invariant_check_flow.png
 
 .. container:: speakernote
 

--- a/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
+++ b/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
@@ -151,7 +151,7 @@ Record Types
 
  .. container:: column
 
-    .. image:: ../../images/record_packing_examples.png
+    .. image:: record_packing_examples.png
        :width: 50%
 
 -------------
@@ -514,7 +514,7 @@ Operands
 
    - `Asm_Input` and `Asm_Output` attributes on types
 
-.. image:: ../../images/annotated_assembly_statement.png
+.. image:: annotated_assembly_statement.png
    :width: 85%
 
 -----------------------------------------

--- a/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
+++ b/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
@@ -46,7 +46,7 @@ Subsystems of Subsystems of ...
 
  .. container:: column
 
-    .. image:: ../../images/connected_cubes.png
+    .. image:: connected_cubes.png
 
 --------------------
 GNAT Project Files

--- a/courses/spark_for_ada_programmers/010_course_overview.rst
+++ b/courses/spark_for_ada_programmers/010_course_overview.rst
@@ -102,7 +102,7 @@ What is SPARK?
 
 |
 
-.. image:: ../../images/ada_vs_spark_venn.png
+.. image:: ada_vs_spark_venn.png
    :width: 85%
 
 =================

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -67,7 +67,7 @@ Combining Proof and Test - Cost Benefit
 
  .. container:: column
 
-    .. image:: ../../images/80-20_provable_or_testable.png
+    .. image:: 80-20_provable_or_testable.png
 
 -------------------------------------
 Language Facilitates Proof and Test
@@ -143,7 +143,7 @@ Math Hidden Behind the Tools
    - Farther back, booster separation-motor plumes are colored by Mach number.
    - Engineers can visualize issues without knowing how visualization is created
 
-.. image:: ../../images/rocket_launch_shock_wave.png
+.. image:: rocket_launch_shock_wave.png
    :width: 30%
    :align: center
    :alt: https://www.nasa.gov/ames/image-feature/simulation-sls-booster-separation

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -37,7 +37,7 @@ SPARK - A Brief History
 
 |
 
-.. image:: ../../images/ada_and_spark_timeline.png
+.. image:: ada_and_spark_timeline.png
    :width: 85%
 
 .. container:: speakernote
@@ -960,7 +960,7 @@ SPARK Key Tools
 :toolname:`GNATprove` Under the Hood
 --------------------------------------
 
-.. image:: ../../images/gnatprove-general_flow.png
+.. image:: gnatprove-general_flow.png
 
 .. container:: speakernote
 
@@ -971,7 +971,7 @@ SPARK Key Tools
 :toolname:`GNATprove` Output for Users
 ----------------------------------------
 
-.. image:: ../../images/gnatprove-output-options.png
+.. image:: gnatprove-output-options.png
 
 ---------------------------------------
 Analysis Summary File "gnatprove.out"
@@ -984,7 +984,7 @@ Analysis Summary File "gnatprove.out"
 
 |
 
-.. image:: ../../images/gnatprove-output-file.jpeg
+.. image:: gnatprove-output-file.jpeg
    :width: 60%
 
 -----------------------------------------------
@@ -1206,13 +1206,13 @@ Two Available IDEs Supporting SPARK
 Basic :toolname:`GNAT Studio` Look and Feel
 ---------------------------------------------
 
-.. image:: ../../images/gnatstudio-look_and_feel.png
+.. image:: gnatstudio-look_and_feel.png
 
 -----------------------------------------
 :toolname:`GNATprove` "SPARK" Main Menu
 -----------------------------------------
 
-.. image:: ../../images/spark_menu-explanations.png
+.. image:: spark_menu-explanations.png
 
 .. container:: speakernote
 
@@ -1224,14 +1224,14 @@ Basic :toolname:`GNAT Studio` Look and Feel
 Project Tree Contextual Menu
 ------------------------------
 
-.. image:: ../../images/spark_rightclick-source_tree.jpeg
+.. image:: spark_rightclick-source_tree.jpeg
    :width: 100%
 
 -----------------------------
 Source Code Contextual Menu
 -----------------------------
 
-.. image:: ../../images/spark_rightclick-code.jpeg
+.. image:: spark_rightclick-code.jpeg
 
 .. container:: speakernote
 
@@ -1241,7 +1241,7 @@ Source Code Contextual Menu
 "Basic" Profile's Proof Dialog Panel
 ---------------------------------------
 
-.. image:: ../../images/prove_dialog-basic.jpeg
+.. image:: prove_dialog-basic.jpeg
 
 .. container:: speakernote
 
@@ -1251,7 +1251,7 @@ Source Code Contextual Menu
 Example Analysis Results in :toolname:`GNAT Studio`
 ----------------------------------------
 
-.. image:: ../../images/gnatprove-output-ide.jpeg
+.. image:: gnatprove-output-ide.jpeg
 
 ----------------------------------
 Preference for Selecting Profile
@@ -1274,13 +1274,13 @@ Preference for Selecting Profile
 
  .. container:: column
 
-    .. image:: ../../images/gnatstudio-preferences-spark.jpeg
+    .. image:: gnatstudio-preferences-spark.jpeg
 
 -------------------------------
 "Advanced" Proof Dialog Panel
 -------------------------------
 
-.. image:: ../../images/prove_dialog-advanced.jpeg
+.. image:: prove_dialog-advanced.jpeg
 
 ========
 Lab

--- a/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
@@ -459,7 +459,7 @@ Flow Analysis Using :toolname:`GNATprove`
 
  .. container:: column
 
-    .. image:: ../../images/spark_menu-examine_file.jpeg
+    .. image:: spark_menu-examine_file.jpeg
 
 ========
 Lab

--- a/courses/spark_for_ada_programmers/070_type_contracts.rst
+++ b/courses/spark_for_ada_programmers/070_type_contracts.rst
@@ -578,14 +578,14 @@ Type Invariant Verifications
 
  .. container:: column
 
-    .. image:: ../../images/black_box_flow.png
+    .. image:: black_box_flow.png
        :width: 100%
 
 ----------------------------------------
 Invariant Over Object Lifetime (Calls)
 ----------------------------------------
 
-.. image:: ../../images/type_invariant_check_flow.png
+.. image:: type_invariant_check_flow.png
 
 ------------------------
 Example Type Invariant

--- a/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
+++ b/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
@@ -156,7 +156,7 @@ Modular Verification
 Modular Verification
 ----------------------
 
-.. image:: ../../images/call_cycle-pre_and_post_condition.png
+.. image:: call_cycle-pre_and_post_condition.png
 
 ---------------------------
 Comparison Test and Proof
@@ -197,7 +197,7 @@ Proof and Test - Hybrid Verification
 * Still modular verification
 * Responsibilities!
 
-.. image:: ../../images/call_cycle-test_pre_prove_post.png
+.. image:: call_cycle-test_pre_prove_post.png
 
 --------------------------------------
 Proof and Test - Hybrid Verification
@@ -207,7 +207,7 @@ Proof and Test - Hybrid Verification
 * Still modular verification
 * Responsibilities!
 
-.. image:: ../../images/call_cycle-prove_pre_test_post.png
+.. image:: call_cycle-prove_pre_test_post.png
 
 ------------------------------------------
 Combining Proof and Test - Cost Benefit
@@ -222,7 +222,7 @@ Combining Proof and Test - Cost Benefit
 
  .. container:: column
 
-    .. image:: ../../images/80-20_provable_or_testable.png
+    .. image:: 80-20_provable_or_testable.png
 
 --------------------------
 Combining Proof and Test
@@ -240,7 +240,7 @@ Combining Proof and Test
 :toolname:`GNATprove` Tool Architecture
 -----------------------------------------
 
-.. image:: ../../images/gnatprove-actual_tool_flow.png
+.. image:: gnatprove-actual_tool_flow.png
 
 ==============
 Summary

--- a/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
+++ b/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
@@ -12,7 +12,7 @@ Introduction
 Run-Time Errors
 -----------------
 
-.. image:: ../../images/coffee_pot_runtime_error.jpeg
+.. image:: coffee_pot_runtime_error.jpeg
 
 ---------------------------
 Run-Time Errors - Example
@@ -195,7 +195,7 @@ Usage
 Usage Scenarios
 -----------------
 
-.. image:: ../../images/when_to_switch_to_spark.png
+.. image:: when_to_switch_to_spark.png
 
 .. container:: speakernote
 

--- a/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
+++ b/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
@@ -24,13 +24,13 @@ Analysis of Failed Proof Attempts
 
  .. container:: column
 
-    .. image:: ../../images/failed_proof_bus_example.png
+    .. image:: failed_proof_bus_example.png
 
 -----------------
 The Proof Cycle
 -----------------
 
-.. image:: ../../images/fortify_analyze_prove_cycle.png
+.. image:: fortify_analyze_prove_cycle.png
 
 .. container:: speakernote
 
@@ -70,7 +70,7 @@ How to Deal with Unproved Checks
 * Clicking on the magnifying glass next to the source line number will highlight the path leading to the unproved check.
 
 |
-.. image:: ../../images/unproved_check_example.png
+.. image:: unproved_check_example.png
    :width: 85%
 
 .. container:: speakernote
@@ -90,7 +90,7 @@ How to Deal with Unproved Checks
 How to Deal with Unproved Checks
 ----------------------------------
 
-.. image:: ../../images/prove_dialog-basic-proof_level.png
+.. image:: prove_dialog-basic-proof_level.png
 
 ----------------------------------
 How to Deal with Unproved Checks

--- a/courses/spark_for_ada_programmers/160_interfacing.rst
+++ b/courses/spark_for_ada_programmers/160_interfacing.rst
@@ -35,7 +35,7 @@ System and SPARK Boundaries
 Interaction With the External Environment
 -------------------------------------------
 
-.. image:: ../../images/interaction_with_environment.png
+.. image:: interaction_with_environment.png
 
 ==================
 External Objects
@@ -112,7 +112,7 @@ External State
 
  .. container:: column
 
-    .. image:: ../../images/valves_and_sensors.jpeg
+    .. image:: valves_and_sensors.jpeg
 
 -----------------------------------
 Package Contracts: External State

--- a/courses/spark_for_ada_programmers/170_designing_for_spark.rst
+++ b/courses/spark_for_ada_programmers/170_designing_for_spark.rst
@@ -227,13 +227,13 @@ Abstraction And Refinement
 Example: An Input Interface Package
 -------------------------------------
 
-.. image:: ../../images/input_interface_package-flat.png
+.. image:: input_interface_package-flat.png
 
 -------------------
 A Better Solution
 -------------------
 
-.. image:: ../../images/input_interface_package-hierarchichal.png
+.. image:: input_interface_package-hierarchichal.png
 
 ------------------------------------
 Effective Use Of State Abstraction

--- a/courses/spark_for_ada_programmers/180_adoption_guidance.rst
+++ b/courses/spark_for_ada_programmers/180_adoption_guidance.rst
@@ -30,14 +30,14 @@ Adoption Guidance Document
 
  .. container:: column
 
-    .. image:: ../../images/thales_adoption_manual.png
+    .. image:: thales_adoption_manual.png
        :width: 100%
 
 -----------------------------------------
 Responding To New Industrial Challenges
 -----------------------------------------
 
-.. image:: ../../images/when_to_switch_to_spark.png
+.. image:: when_to_switch_to_spark.png
 
 .. container:: speakernote
 

--- a/pandoc/pandoc_fe.py
+++ b/pandoc/pandoc_fe.py
@@ -155,7 +155,7 @@ if __name__== "__main__":
 
     parser.add_argument('--directories',
                         help='Comma-separated list of folders to search for things like images and Beamer themes',
-                        default=str(ROOT) + "//,:",
+                        default=f"{ROOT}//,:{ROOT}/images:",
                         required=False)
 
     parser.add_argument('--title',


### PR DESCRIPTION
Having relative `../../images/` paths cause a lot of issues with pandoc and tex2pdf: it creates temporary directories in weird places...

This PR adds the `images/` directory to pandoc's "ressource-path"  and remove all reference to relative paths in the rst files.