### PR TITLE
Pandoc: beamer implicit roles

### DIFF
--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -5,6 +5,19 @@
 Overview
 **********
 
+===================
+About This Course
+===================
+
+--------
+Styles
+--------
+
+* :dfn:`This` is a definition
+* :filename:`this/is/a.path`
+* :ada:`code is highlighted`
+* :command:`commands are emphasised --like-this`
+
 ==================
 A Little History
 ==================
@@ -77,13 +90,13 @@ Big Picture
 Language Structure (Ada95 and Onward)
 ---------------------------------------
 
-* **Required** *Core* implementation
+* **Required** :dfn:`Core` implementation
 
    - Reference Manual (RM) sections 1 :math:`\rightarrow` 13
    - Predefined Language Environment (Annex A)
    - Foreign Language Interfaces (Annex B)
 
-* Optional *Specialized Needs Annexes*
+* Optional :dfn:`Specialized Needs Annexes`
 
    - No additional syntax
    - Systems Programming (C)

--- a/pandoc/beamer_filter.py
+++ b/pandoc/beamer_filter.py
@@ -6,7 +6,7 @@ Special handling done by this filter:
       - toolname => small caps
       - menu => colored box with white text
       - command => black box with monospaced white text
-      - filename => bold italic
+      - filename => bold monospaced on light yellow background
    + Search TEXINPUTS environment variable for paths to find images
    + Slides are vertically aligned to the top, with the 'shrink' attribute
      so everything fits one the page
@@ -106,8 +106,8 @@ def latex_box ( text, color='adacore2' ):
 def latex_color ( text, color='white' ):
     return "\\textcolor{" + color + "}{" + text + "}"
 
-def latex_bold_italic ( text ):
-    return "\\textbf{\\textit{" + text + "}}"
+def latex_bold ( text ):
+    return "\\textbf{" + text + "}"
 
 def latex_monospace ( text ):
     return "\\texttt{" + text + "}"
@@ -540,8 +540,8 @@ def format_command ( literal_text ):
 (items that indicate a particular filename/folder)
 '''
 def format_filename ( literal_text ):
-   # bold and italic
-   return latex_inline ( latex_bold_italic ( latex_escape ( literal_text ) ) )
+   # bold monospaced on light yellow background
+   return latex_inline ( latex_box ( latex_bold ( latex_monospace ( latex_escape ( literal_text ) ) ), "lightyellow") )
 
 '''
 "answer" role

--- a/pandoc/beamer_filter.py
+++ b/pandoc/beamer_filter.py
@@ -113,7 +113,8 @@ def latex_monospace ( text ):
     return "\\texttt{" + text + "}"
 
 def latex_escape ( text ):
-    return text.replace('_', '\\_' ).replace('&', '\\&').replace('#', '\\#')
+    # For "--": https://tex.stackexchange.com/questions/9813/how-can-i-stop-latex-from-converting-two-hyphens-to-a-single-hyphen-when-loading
+    return text.replace('_', '\\_' ).replace('&', '\\&').replace('#', '\\#').replace("--", "-{}-")
 
 def latex_answer ( text ):
     return "\\textit<2>{\\textbf<2>{\\textcolor<2>{green!65!black}{" + text + "}}}"

--- a/pandoc/beamer_filter.py
+++ b/pandoc/beamer_filter.py
@@ -55,6 +55,7 @@ role_format_functions = { 'toolname'   : 'SmallCaps',
                           'url'        : 'format_url',
                           'menu'       : 'format_menu',
                           'command'    : 'format_command',
+                          'dfn'        : 'format_dfn',
                           'answer'     : 'format_answer',
                           'answermono' : 'format_answermono',
                           'animate'    : 'format_animate',
@@ -108,6 +109,12 @@ def latex_color ( text, color='white' ):
 
 def latex_bold ( text ):
     return "\\textbf{" + text + "}"
+
+def latex_italic ( text ):
+    return "\\textit{" + text + "}"
+
+def latex_bold_italic ( text ):
+    return "\\textbf{\\textit{" + text + "}}"
 
 def latex_monospace ( text ):
     return "\\texttt{" + text + "}"
@@ -534,6 +541,14 @@ def format_url ( literal_text ):
 def format_command ( literal_text ):
    # white text on box of black
    return latex_inline ( latex_box ( latex_color ( latex_monospace ( latex_escape ( literal_text ) ) ), "black" ) )
+
+'''
+"dfn" role
+Items that indicate a term definition
+'''
+def format_dfn ( literal_text ):
+   return latex_inline ( latex_box ( latex_color ( latex_italic (
+        latex_escape (literal_text) ) ), "cyan" ) )
 
 '''
 "filename" role

--- a/support_files/beamercolorthemeadacore.sty
+++ b/support_files/beamercolorthemeadacore.sty
@@ -12,6 +12,7 @@
 \definecolor{adacore1}{RGB}{18,40,76}      %% lovelace blue
 \definecolor{adacore2}{RGB}{224,124,0}     %% orange
 \definecolor{adacore3}{RGB}{185,198,215}   %% light blue
+\definecolor{lightyellow}{RGB}{240,230,160}
 
 \setbeamercolor*{palette primary}{fg=adacore1,bg=adacore3}
 \setbeamercolor*{palette secondary}{fg=adacore2,bg=adacore3}


### PR DESCRIPTION
Add the `:dfn:` role for definitions
Add a "Syntax" slide to overview displaying examples of syntax used in the slides
Modify the `:filename:` role to make it more distinct from normal text
Fix the `:command:` role to escape double-hyphens