### PR TITLE
RST prelude for roles

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,6 +38,10 @@ jobs:
       - name: Install python dependencies
         run: pip install pandocfilters
 
+      
+      - name: Check source is updated with prelude
+        run: python contrib/ci/fix_prelude.py
+
 
       - name: Generate slides for Ada fundamentals
         run: python pandoc/pandoc_fe.py --output-dir out/fundamentals_of_ada --hush --extension pdf --source courses/fundamentals_of_ada/*.rst

--- a/contrib/ci/fix_prelude.py
+++ b/contrib/ci/fix_prelude.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+from pathlib import Path
+import subprocess
+import argparse
+import hashlib
+
+
+PROJECT = Path(sys.argv[0]).resolve().parents[2]
+CONTRIB = PROJECT / "contrib"
+
+
+def rst_update_prelude(files):
+    subprocess.check_call(str(s) for s in
+                          [sys.executable, CONTRIB / 'rst_update_prelude.py', '-i'] + files)
+
+
+def files_digest(files):
+    h = hashlib.sha256()
+    for f in sorted(files):
+        with open(f, 'rb') as frd:
+            h.update(frd.read())
+    return h.digest()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--files-to-check", type=Path,
+                    default=CONTRIB / "rst_files_with_prelude.txt")
+    ap.add_argument("--no-digests-check", "-C", action="store_true")
+    args = ap.parse_args()
+
+    check_digest = not args.no_digests_check
+    digests_have_changed = False
+
+    with open(args.files_to_check, "rt") as f:
+        files_with_prelude_glob = f.read().splitlines()
+    
+    for glob in files_with_prelude_glob:
+        f_prel = list(PROJECT.glob(glob))
+        if not f_prel:
+            continue
+
+        print(glob)
+        if check_digest:
+            before = files_digest(f_prel)
+
+        rst_update_prelude(f_prel)
+        if check_digest and before != files_digest(f_prel):
+            print(f"{glob}: files didn't have the proper prelude", file=sys.stderr)
+            print(f"run {Path(sys.argv[0]).name} locally and commit the results to fix")
+            digests_have_changed = True
+
+    if check_digest:
+        sys.exit(0 if not digests_have_changed else 1)

--- a/contrib/rst_files_with_prelude.txt
+++ b/contrib/rst_files_with_prelude.txt
@@ -1,0 +1,1 @@
+courses/fundamentals_of_ada/*.rst

--- a/contrib/rst_update_prelude.py
+++ b/contrib/rst_update_prelude.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import argparse
+from pathlib import Path
+
+
+CWD = Path(sys.argv[0]).resolve().parents[1]
+
+
+def section_start(l):
+    return len(l) > 2 and l[0] == l[1] and l[1] == l[2] and l[0] in "*-=+"
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prelude", default=CWD / 'support_files' / 'prelude.rst')
+    ap.add_argument("--in-place", "-i", action='store_true')
+    ap.add_argument("files", nargs="+")
+    args = ap.parse_args()
+
+    with open(args.prelude, 'rt') as pf:
+        prelude_content = pf.read()
+
+    if prelude_content.endswith(os.linesep):
+        prelude_content = prelude_content[:-1]
+
+    for f in args.files:
+        with open(f, 'rt') as ff:
+            file_lines = ff.read().splitlines()
+
+        f_out = open(f, 'wt') if args.in_place else sys.stdout
+
+        def print_out(*a, **kw):
+            kw.setdefault("file", f_out)
+            print(*a, **kw)
+    
+        STATE_INIT, STATE_CHAPTER, STATE_END = 0, 1, 2
+        state = STATE_INIT
+        skip = 0
+        for l in file_lines:
+            if skip:
+                skip -= 1
+                print_out(l)
+            elif state == STATE_INIT:
+                if section_start(l):
+                    state = STATE_CHAPTER
+                    skip = 3
+                    print_out(l)
+            elif state == STATE_CHAPTER:    
+                if section_start(l):
+                    print_out(prelude_content)
+                    print_out()
+                    print_out(l)
+                    state = STATE_END
+            elif state == STATE_END:
+                print_out(l)

--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -1,9 +1,31 @@
-.. role:: ada(code)
-    :language: ada
-
 **********
 Overview
 **********
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ===================
 About This Course

--- a/courses/fundamentals_of_ada/020_declarations.rst
+++ b/courses/fundamentals_of_ada/020_declarations.rst
@@ -1,14 +1,31 @@
-.. |equivalent| replace:: :math:`\iff`
+**************
+Declarations
+**************
 
-.. role:: c(code)
-    :language: C
+..
+    Coding language
 
 .. role:: ada(code)
     :language: Ada
 
-**************
-Declarations
-**************
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -2,16 +2,30 @@
 Basic Types
 *************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
 
 .. role:: C(code)
-   :language: C
+    :language: C
 
 .. role:: cpp(code)
-   :language: C++
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ================
 Introduction

--- a/courses/fundamentals_of_ada/040_statements.rst
+++ b/courses/fundamentals_of_ada/040_statements.rst
@@ -2,16 +2,30 @@
 Statements
 ************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
 
 .. role:: C(code)
-   :language: C
+    :language: C
 
 .. role:: cpp(code)
-   :language: C++
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -1,10 +1,31 @@
-
 *************
 Array Types
 *************
 
+..
+    Coding language
+
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/060_record_types.rst
+++ b/courses/fundamentals_of_ada/060_record_types.rst
@@ -2,16 +2,30 @@
 Record Types
 **************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
 
 .. role:: C(code)
-   :language: C
+    :language: C
 
 .. role:: cpp(code)
-   :language: C++
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/065_type_derivation.rst
+++ b/courses/fundamentals_of_ada/065_type_derivation.rst
@@ -2,11 +2,30 @@
 Type Derivation
 ***************
 
-.. role:: cpp(code)
-    :language: C++
+..
+    Coding language
 
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/070_subprograms.rst
+++ b/courses/fundamentals_of_ada/070_subprograms.rst
@@ -2,8 +2,30 @@
 Subprograms
 *************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/080_expressions.rst
+++ b/courses/fundamentals_of_ada/080_expressions.rst
@@ -2,10 +2,30 @@
 Expressions
 *************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/090_overloading.rst
+++ b/courses/fundamentals_of_ada/090_overloading.rst
@@ -1,10 +1,31 @@
-
 *************
 Overloading
 *************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/095_library_units.rst
+++ b/courses/fundamentals_of_ada/095_library_units.rst
@@ -1,7 +1,31 @@
-
 ****************
 Library Units
 ****************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/100_packages.rst
+++ b/courses/fundamentals_of_ada/100_packages.rst
@@ -1,10 +1,31 @@
-
 **********
 Packages
 **********
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/110_private_types.rst
+++ b/courses/fundamentals_of_ada/110_private_types.rst
@@ -1,10 +1,31 @@
-
 ***************
 Private Types
 ***************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/120_limited_types.rst
+++ b/courses/fundamentals_of_ada/120_limited_types.rst
@@ -2,8 +2,30 @@
 Limited Types
 ***************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/130_program_structure.rst
+++ b/courses/fundamentals_of_ada/130_program_structure.rst
@@ -1,10 +1,31 @@
-
 *******************
 Program Structure
 *******************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/135_visibility.rst
+++ b/courses/fundamentals_of_ada/135_visibility.rst
@@ -1,7 +1,31 @@
-
 ************
 Visibility
 ************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -1,10 +1,31 @@
-
 **************
 Access Types
 **************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/160_genericity.rst
+++ b/courses/fundamentals_of_ada/160_genericity.rst
@@ -2,10 +2,30 @@
 Genericity
 ************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/170_tagged_derivation.rst
+++ b/courses/fundamentals_of_ada/170_tagged_derivation.rst
@@ -1,10 +1,31 @@
-
 *****************
 Tagged Derivation
 *****************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -2,10 +2,30 @@
 Polymorphism
 **************
 
-.. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
 
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/190_exceptions.rst
+++ b/courses/fundamentals_of_ada/190_exceptions.rst
@@ -1,12 +1,31 @@
-
 ************
 Exceptions
 ************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
 
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/230_interfacing_with_c.rst
+++ b/courses/fundamentals_of_ada/230_interfacing_with_c.rst
@@ -1,13 +1,31 @@
-
 **********************
 Interfacing with C
 **********************
 
+..
+    Coding language
+
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
 
 .. role:: C(code)
-   :language: C
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/240_tasking.rst
+++ b/courses/fundamentals_of_ada/240_tasking.rst
@@ -1,16 +1,31 @@
-
 *********
 Tasking
 *********
 
+..
+    Coding language
+
 .. role:: ada(code)
-   :language: ada
+    :language: Ada
 
 .. role:: C(code)
-   :language: C
+    :language: C
 
 .. role:: cpp(code)
-   :language: C++
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ================
 Introduction

--- a/courses/fundamentals_of_ada/900_ada_version_comparison.rst
+++ b/courses/fundamentals_of_ada/900_ada_version_comparison.rst
@@ -2,6 +2,29 @@
 Annex - Ada Version Comparison
 ********************************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
 .. |checkmark| replace:: :math:`\checkmark`
 
 ---------------

--- a/courses/fundamentals_of_ada/915_predefined_libraries.rst
+++ b/courses/fundamentals_of_ada/915_predefined_libraries.rst
@@ -2,6 +2,31 @@
 Annex - Predefined Libraries
 ******************************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
+
 -------------------------
 Ada Top-Level Namespace
 -------------------------

--- a/courses/fundamentals_of_ada/920_reference_material.rst
+++ b/courses/fundamentals_of_ada/920_reference_material.rst
@@ -1,7 +1,31 @@
-
 *****************************
 Annex - Reference Materials
 *****************************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==========================
 General Ada Information

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -1,7 +1,31 @@
-
 ****************************
 Discriminated Record Types
 ****************************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_080_quantified_expressions.rst
+++ b/courses/fundamentals_of_ada/adv_080_quantified_expressions.rst
@@ -2,8 +2,30 @@
 Quantified Expressions
 ************************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ========================
 Quantified Expressions

--- a/courses/fundamentals_of_ada/adv_090_overloading_equality.rst
+++ b/courses/fundamentals_of_ada/adv_090_overloading_equality.rst
@@ -1,10 +1,31 @@
-
 **********************
 Overloading Equality
 **********************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_120_advanced_privacy.rst
+++ b/courses/fundamentals_of_ada/adv_120_advanced_privacy.rst
@@ -1,7 +1,31 @@
-
 ******************
 Advanced Privacy
 ******************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ============
 Type Views

--- a/courses/fundamentals_of_ada/adv_170_multiple_inheritance.rst
+++ b/courses/fundamentals_of_ada/adv_170_multiple_inheritance.rst
@@ -2,6 +2,31 @@
 Multiple Inheritance
 **********************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
+
 ==============
 Introduction
 ==============

--- a/courses/fundamentals_of_ada/adv_190_exceptions.rst
+++ b/courses/fundamentals_of_ada/adv_190_exceptions.rst
@@ -1,12 +1,31 @@
-
 *********************
 Advanced Exceptions
 *********************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
 
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 =============
 Introduction

--- a/courses/fundamentals_of_ada/adv_240_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_240_tasking.rst
@@ -1,10 +1,31 @@
-
 *********
 Tasking
 *********
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
@@ -1,7 +1,31 @@
-
 *******************
 Ravenscar Tasking
 *******************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_250_containers.rst
+++ b/courses/fundamentals_of_ada/adv_250_containers.rst
@@ -1,7 +1,31 @@
-
 ************
 Containers
 ************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_260_controlled_types.rst
+++ b/courses/fundamentals_of_ada/adv_260_controlled_types.rst
@@ -1,7 +1,31 @@
-
 ******************
 Controlled Types
 ******************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
@@ -2,8 +2,30 @@
 Subprogram Contracts
 **********************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_275_type_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_275_type_contracts.rst
@@ -1,10 +1,31 @@
-
 ****************
 Type Contracts
 ****************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
+++ b/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
@@ -2,7 +2,30 @@
 Low Level Programming
 ***********************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/spec_870_gnat_options.rst
+++ b/courses/fundamentals_of_ada/spec_870_gnat_options.rst
@@ -2,7 +2,30 @@
 Annex - GNAT options
 **********************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ------------------------------------
 Understanding the GNAT Build Steps

--- a/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
+++ b/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
@@ -1,7 +1,31 @@
-
 ********************
 Annex - GPR Basics
 ********************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/spec_880_elaboration.rst
+++ b/courses/fundamentals_of_ada/spec_880_elaboration.rst
@@ -1,10 +1,31 @@
-
 *************
 Elaboration
 *************
 
+..
+    Coding language
+
 .. role:: ada(code)
     :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/fundamentals_of_ada/spec_890_ada_text_io.rst
+++ b/courses/fundamentals_of_ada/spec_890_ada_text_io.rst
@@ -1,7 +1,31 @@
-
 ******************
 Ada.Text_IO
 ******************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/support_files/prelude.rst
+++ b/support_files/prelude.rst
@@ -1,0 +1,24 @@
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`


### PR DESCRIPTION
Pandoc has a lot of bugs related to include files that contain roles. On the other hand we want to share a common context to all rst files (eg. `:ada:` role).

Solution used there is to have a `contrib/update_rst_prelude.py` script that copies the content of `support_files/prelude.rst` at the top of a file. The copy happens after the chapter title for two reason:

1. A quick `head` command shows the slideset title
2. Some roles and directive have issues when they are placed above any title

This commit also adds a github CI safety script under `contrib/ci/fix_prelude.py` that will refuse to build if the prelude set on the files specified in `contrib/rst_files_with_prelude.txt` is incorrect. Note that this script is both setting and checking the prelude, so it can be used locally as a pre-push action to set the preludes straight. Only checking it for `courses/fundamentals_of_ada` at the moment.
