### PR TITLE
CI Labs: Early pkg failures

### DIFF
--- a/contrib/ci/package_labs.py
+++ b/contrib/ci/package_labs.py
@@ -16,7 +16,9 @@ def check_call(*args, **kw):
     al = [str(s) for s in args]
     if verbose:
         print(" ".join(al))
-    subprocess.check_call(al, **kw)
+    rc = subprocess.call(al, **kw)
+    if rc != 0:
+        sys.exit(2)
 
 def python(script, *args, **kw):
     assert script.is_file()

--- a/courses/fundamentals_of_ada/labs/radar/020_declarations/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/radar/020_declarations/instructions.rst
@@ -1,6 +1,7 @@
 :title: Ada Fundamentals - Lab 1 - Declarations
 
-.. include:: support_files/docs_common.rst
+.. role:: ada(code)
+   :language: ada
 
 The purpose of this lab is to discover the basics of the GNAT toolchain on Windows
 and to put that knowledge to use by declaring some variables.

--- a/courses/fundamentals_of_ada/labs/radar/030_basic_types/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/radar/030_basic_types/instructions.rst
@@ -1,6 +1,7 @@
 :title: Ada Fundamentals - Lab 2 - Basic Types
 
-.. include:: support_files/docs_common.rst
+.. role:: ada(code)
+   :language: ada
 
 The purpose of this lab is to present basic Ada types and some advanced :toolname:`GNAT Studio`
 features.

--- a/courses/fundamentals_of_ada/labs/radar/040_statements/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/radar/040_statements/instructions.rst
@@ -1,6 +1,7 @@
 :title: Ada Fundamentals - Lab 3 - Statements
 
-.. include:: support_files/docs_common.rst
+.. role:: ada(code)
+   :language: ada
 
 The purpose of this lab is to understand the various statements, and how they
 can be used to make the code more terse.

--- a/courses/gnatstudio/getting_started_lab_1.rst
+++ b/courses/gnatstudio/getting_started_lab_1.rst
@@ -1,4 +1,5 @@
-.. include:: support_files/docs_common.rst
+.. role:: ada(code)
+   :language: ada
 
 ---------------
 Getting Started

--- a/courses/gnatstudio/navigate_debug_lab_2.rst
+++ b/courses/gnatstudio/navigate_debug_lab_2.rst
@@ -1,4 +1,5 @@
-.. include:: support_files/docs_common.rst
+.. role:: ada(code)
+   :language: ada
 
 -----------------
 Navigate the code

--- a/courses/gnatstudio/support_files
+++ b/courses/gnatstudio/support_files
@@ -1,1 +1,0 @@
-../../support_files

--- a/pandoc/lab_docs.py
+++ b/pandoc/lab_docs.py
@@ -9,12 +9,17 @@ CURRENT_DIR = Path(sys.argv[0]).parent.resolve()
 
 def lab_doc(input, output, default_args, args):
     print(f"{input} -> {output}")
-    subprocess.check_call(f"pandoc " + \
-                          f"--data-dir={(CURRENT_DIR.parent / 'support_files').resolve()} " + \
-                          f"{input.resolve()} -o {output.resolve()} " + \
-                          f"{default_args} {' '.join(args)}",
-                          cwd=CURRENT_DIR.parent,
-                          shell=True)
+    rc = subprocess.call(f"pandoc " + \
+                         f"--data-dir={(CURRENT_DIR.parent / 'support_files').resolve()} " + \
+                         "--fail-if-warning " + \
+                         f"{input.resolve()} -o {output.resolve()} " + \
+                         f"{default_args} {' '.join(args)}",
+                         cwd=CURRENT_DIR.parent,
+                         shell=True)
+
+    if rc != 0:   
+        print(f"\033[1;31mpandoc failed\033[0m on {input}", file=sys.stderr)
+        sys.exit(2)
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()

--- a/pandoc/lab_docs.py
+++ b/pandoc/lab_docs.py
@@ -7,15 +7,21 @@ import parse_pandoc_defaults
 
 CURRENT_DIR = Path(sys.argv[0]).parent.resolve()
 
+def call(*a, **kw):
+    print("+", *a)
+    print("K", kw)
+    return subprocess.call(a, **kw)
+
+
 def lab_doc(input, output, default_args, args):
     print(f"{input} -> {output}")
-    rc = subprocess.call(f"pandoc " + \
-                         f"--data-dir={(CURRENT_DIR.parent / 'support_files').resolve()} " + \
-                         "--fail-if-warning " + \
-                         f"{input.resolve()} -o {output.resolve()} " + \
-                         f"{default_args} {' '.join(args)}",
-                         cwd=CURRENT_DIR.parent,
-                         shell=True)
+    rc = call(f"pandoc " + \
+              f"--data-dir={(CURRENT_DIR.parent / 'support_files').resolve()} " + \
+              "--fail-if-warning " + \
+              f"{input.resolve()} -o {output.resolve()} " + \
+              f"{default_args} {' '.join(args)}",
+              cwd=CURRENT_DIR.parent,
+              shell=True)
 
     if rc != 0:   
         print(f"\033[1;31mpandoc failed\033[0m on {input}", file=sys.stderr)

--- a/support_files/README.md
+++ b/support_files/README.md
@@ -17,11 +17,6 @@ Beamer color theme using AdaCore's standard coloring scheme
 Beamer theme for generating slides with a simple format
 where each slide contains a hierarchical reminder of its location
 
-## docs_common.rst
-
-For use in documents RST files: common tags and settings (Warning: variabless won't be shared when
-included with pandoc).
-
 ## templates/
 
 Pandoc templates

--- a/support_files/docs_common.rst
+++ b/support_files/docs_common.rst
@@ -1,2 +1,0 @@
-.. role:: ada(code)
-   :language: ada


### PR DESCRIPTION
When packaging labs, stop ignoring warnings and treat them as failures instead.
Improve the failure messages as well, by hiding the useless python stacktraces in case of subprogram failure.
