### PR TITLE
pandoc: beamer filter fix answer not displaying

### DIFF
--- a/pandoc/beamer_filter.py
+++ b/pandoc/beamer_filter.py
@@ -439,10 +439,11 @@ def format_text ( key, value, format ):
    elif ( key == "Code" and
           'interpreted-text' in classes and
           kvs[0][0] == 'role'):
-      n = perform_role ( kvs[0][1], text, format )
-      if n == None:
+      res = perform_role ( kvs[0][1], text, format )
+      if res == None:
          # Fallback returns default
-         return pandoc_format ( 'default', literal_to_AST_node ( text ) )
+         res = pandoc_format ( 'default', literal_to_AST_node ( text ) )
+      return res
 
 '''
 pandoc_format takes the name of a pandoc emphasis function and


### PR DESCRIPTION
A bug was introduced with the changes to the beamer filter: it no longer applied some roles, such as `answer`, this fixes this issue
