### PR TITLE
Add definitions as `:dfn:`, minor fixes

### DIFF
--- a/courses/fundamentals_of_ada/020_declarations.rst
+++ b/courses/fundamentals_of_ada/020_declarations.rst
@@ -298,7 +298,7 @@ Examples
 Declarations
 --------------
 
-* Associate a **name** to an **entity**
+* Associate a :dfn:`name` to an :dfn:`entity`
 
     - Objects
     - Types
@@ -610,13 +610,13 @@ Examples
 Scope and Visibility
 ----------------------
 
-* **Scope** of a name
+* :dfn:`Scope` of a name
 
    - Where the name is **potentially** available
    - Determines **lifetime**
    - Scopes can be **nested**
 
-* **Visibility** of a name
+* :dfn:`Visibility` of a name
 
    - Where the name is **actually** available
    - Defined by **visibility rules**

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -35,11 +35,11 @@ Introduction
 Ada Type Model
 ----------------
 
-* **Static** Typing
+* :dfn:`Static` Typing
 
    - Object type **cannot change**
 
-* **Strong** Typing
+* :dfn:`Strong` Typing
 
    - By **name**
    - **Compiler-enforced** operations and values
@@ -50,10 +50,10 @@ Ada Type Model
 Strong Typing
 ---------------
 
-* Definition of **type**
+* Definition of :dfn:`type`
 
    - Applicable **values**
-   - Applicable **operations**
+   - Applicable :dfn:`primitive` **operations**
 
 * Compiler-enforced
 
@@ -81,6 +81,8 @@ A Little Terminology
       type Type_1 is digits 12; -- floating-point
       type Type_2 is range -200 .. 200; -- signed integer
       type Type_3 is mod 256; -- unsigned integer
+
+* :dfn:`Representation` is the memory-layout of an **object** of the type
 
 -------------------------
 Ada "Named Typing"

--- a/courses/fundamentals_of_ada/040_statements.rst
+++ b/courses/fundamentals_of_ada/040_statements.rst
@@ -77,7 +77,7 @@ Procedure Calls (Overview)
 Parameter Associations In Calls
 ---------------------------------
 
-* Traditional "positional association" is allowed
+* Traditional :dfn:`positional association` is allowed
 
    - Nth actual parameter goes to nth formal parameter
 
@@ -85,7 +85,7 @@ Parameter Associations In Calls
 
    Activate ( Idle, True ); -- positional
 
-* "Named association" also allowed
+* :dfn:`Named association` also allowed
 
    - Name of formal parameter is explicit
 
@@ -238,7 +238,7 @@ Assignment Statements, Not Expressions
 Assignable Views
 ------------------
 
-* Views control the way an entity can be treated
+* A :dfn:`view` controls the way an entity can be treated
 
    - At different points in the program text
 
@@ -827,7 +827,7 @@ Low-Level For-loop Parameter Type
 Null Ranges
 -------------
 
-    * Null range when lower bound ``>`` upper bound
+    * :dfn:`Null range` when lower bound ``>`` upper bound
 
        - :ada:`1 .. 0`, :ada:`Fri .. Mon`
        - Literals and variables can specify null ranges

--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -52,11 +52,11 @@ Introduction
 Terminology
 -------------
 
-* Index type
+* :dfn:`Index type`
 
    - Specifies the values to be used to access the array components
 
-* Component type
+* :dfn:`Component type`
 
    - Specifies the type of values contained by objects of the array type
    - All components are of this same type
@@ -116,12 +116,12 @@ Run-Time Index Checking
 Kinds of Array Types
 ----------------------
 
-* Constrained Array Types
+* :dfn:`Constrained` Array Types
 
    - Bounds specified by type declaration
    - All objects of the type have the same bounds
 
-* Unconstrained Array Types
+* :dfn:`Unconstrained` Array Types
 
    - Bounds not specified by type declaration
    - More flexible
@@ -1370,7 +1370,7 @@ Summary
 Final Notes on Type `String`
 ------------------------------
 
-* Any single-dimensioned array of some character type is a string type
+* Any single-dimensioned array of some character type is a :dfn:`string type`
 
    - Language defines types `String`, `Wide_String`, etc.
 

--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -748,7 +748,7 @@ Slicing
 ---------
 
 * Contiguous subsection of an array
-* On any one-dimensional array type
+* On any **one-dimensional** array type
 
   - Any component type
 

--- a/courses/fundamentals_of_ada/060_record_types.rst
+++ b/courses/fundamentals_of_ada/060_record_types.rst
@@ -512,7 +512,7 @@ Defaults Within Record Aggregates
 
    Ada 2005
 
-* Specified via the ``box`` notation
+* Specified via the :dfn:`box` notation
 * Value for the component is thus taken as for a stand-alone object declaration
 
    - So there may or may not be a defined default!
@@ -596,12 +596,12 @@ Discriminated Records
 Discriminated Record Types
 ----------------------------
 
-* **Discriminated** record type
+* :dfn:`Discriminated record` type
 
    + Different **objects** may have **different** components
    + All object **still** share the same type
 
-* Kind of **storage overlay**
+* Kind of :dfn:`storage overlay`
 
    + Similar to :C:`union` in C
    + But preserves **type checking**
@@ -626,7 +626,7 @@ Discriminants
      end case;
   end record;
 
-* :ada:`Group` is the **discriminant**
+* :ada:`Group` is the :dfn:`discriminant`
 * Run-time check for component **consistency**
 
    + eg :ada:`A_Person.Pubs := 1` checks :ada:`A_Person.Group = Faculty`

--- a/courses/fundamentals_of_ada/065_type_derivation.rst
+++ b/courses/fundamentals_of_ada/065_type_derivation.rst
@@ -35,7 +35,7 @@ Introduction
 Type Derivation
 -----------------
 
-* Type derivation allows for reusing code
+* Type :dfn:`derivation` allows for reusing code
 * Type can be **derived** from a **base type**
 * Base type can be substituted by the derived type
 * Subprograms defined on the base type are **inherited** on derived type

--- a/courses/fundamentals_of_ada/070_subprograms.rst
+++ b/courses/fundamentals_of_ada/070_subprograms.rst
@@ -317,11 +317,11 @@ Examples
 Subprogram Parameter Terminology
 ----------------------------------
 
-* *Actual* parameters are values passed to a call
+* :dfn:`Actual parameters` are values passed to a call
 
    - Variables, constants, expressions
 
-* *Formal* parameters are defined by specification
+* :dfn:`Formal parameters` are defined by specification
 
    - Receive the values passed from the actual parameters
    - Specify the types required of the actual parameters
@@ -1027,7 +1027,7 @@ Order-Dependent Code And Side Effects
 Parameter Aliasing
 --------------------
 
-* **Aliasing** : Multiple names for an actual parameter inside a subprogram body
+* :dfn:`Aliasing`: Multiple names for an actual parameter inside a subprogram body
 * Possible causes:
 
    - Global object used is also passed as actual parameter

--- a/courses/fundamentals_of_ada/090_overloading.rst
+++ b/courses/fundamentals_of_ada/090_overloading.rst
@@ -35,7 +35,7 @@ Introduction
 Introduction
 --------------
 
-* Overloading is the use of an already existing name to define a **new** entity
+* :dfn:`Overloading` is the use of an already existing name to define a **new** entity
 * Historically, only done as part of the language **implementation**
 
    - Eg. on operators
@@ -218,7 +218,7 @@ Call Resolution
 -----------------
 
 * Compilers must reject ambiguous calls
-* Resolution is based on the calling context
+* :dfn:`Resolution` is based on the calling context
 
    - Compiler attempts to find a matching **profile**
    - Based on **Parameter** and **Result** Type

--- a/courses/fundamentals_of_ada/100_packages.rst
+++ b/courses/fundamentals_of_ada/100_packages.rst
@@ -56,7 +56,7 @@ Packages
 Separating Interface and Implementation
 -----------------------------------------
 
-* Implementation and specification are textually distinct from each other
+* :dfn:`Implementation` and :dfn:`specification` are textually distinct from each other
 
    - Typically in separate files
 
@@ -250,7 +250,7 @@ Package Bodies
 
    - Any code that would require editing would not have compiled in the first place
 
-* Required when specification contains declarations requiring completions it cannot contain
+* Necessary for specifications that require a completion, for example:
 
    - Subprogram bodies
    - Task bodies

--- a/courses/fundamentals_of_ada/110_private_types.rst
+++ b/courses/fundamentals_of_ada/110_private_types.rst
@@ -167,13 +167,13 @@ Declaring Private Types for Views
 Partial and Full Views of Types
 ---------------------------------
 
-* Private type declaration defines a partial view
+* Private type declaration defines a :dfn:`partial view`
 
    - The type name is visible
    - Only designer's operations and some predefined operations
    - No references to full type representation
 
-* Full type declaration defines the full view
+* Full type declaration defines the :dfn:`full view`
 
    - Fully defined as a record type, scalar, imported type, etc...
    - Just an ordinary type within the package
@@ -692,8 +692,8 @@ Effects of Hiding Type Representation
 
 * Common idioms are a result
 
-   - *Constructors*
-   - *Selectors*
+   - :dfn:`Constructor`
+   - :dfn:`Selector`
 
 --------------
 Constructors

--- a/courses/fundamentals_of_ada/130_program_structure.rst
+++ b/courses/fundamentals_of_ada/130_program_structure.rst
@@ -49,7 +49,7 @@ What is a System?
 -------------------
 
 * Also called Application or Program or ...
-* Collection of library units
+* Collection of :dfn:`library units`
 
    - Which are a collection of packages, subprograms, objects
 
@@ -162,10 +162,10 @@ Illegal Package Declaration Dependency
 
    - Controlled cycles are now permitted
 
-* Provide a "limited" view of the specified package
+* Provide a :dfn:`limited view` of the specified package
 
    - Only type names are visible (including in nested packages)
-   - Types are viewed as *incomplete types*
+   - Types are viewed as :dfn:`incomplete types`
 
 * Normal view
 
@@ -326,7 +326,7 @@ Solution: Hierarchical Library Units
 Programming By Extension
 --------------------------
 
-* Parent unit
+* :dfn:`Parent unit`
 
    .. code:: Ada
 

--- a/courses/fundamentals_of_ada/135_visibility.rst
+++ b/courses/fundamentals_of_ada/135_visibility.rst
@@ -55,7 +55,7 @@ Improving Readability
 Operators and Primitives
 --------------------------
 
-* *Operators*
+* :dfn:`Operators`
 
    - Constructs which behave generally like functions but which differ syntactically or semantically.
    - Typically arithmetic, comparison, and logical
@@ -86,7 +86,7 @@ Examples
 
 * Provide direct visibility into packages' exported items
 
-   + *Direct Visibility* - as if object was referenced from within package being used
+   + :dfn:`Direct Visibility` - as if object was referenced from within package being used
 
 * May still use expanded name
 

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -36,7 +36,7 @@ Access Types Design
 ---------------------
 
 * Memory addresses objects are called :dfn:`access types`
-* Objects are associated to **pools** of memory
+* Objects are associated to :dfn:`pools` of memory
 
   - With different allocation / deallocation policies
 
@@ -440,7 +440,7 @@ Examples
 Introduction to Accessibility Checks (1/2)
 --------------------------------------------
 
-* The depth of an object depends on its nesting within declarative scopes
+* The :dfn:`depth` of an object depends on its nesting within declarative scopes
 
    .. code:: Ada
 
@@ -681,7 +681,7 @@ Anonymous Access Parameters
 -----------------------------
 
 * Parameter modes are of 4 types: :ada:`in`, :ada:`out`, :ada:`in out`, :ada:`access`
-* The access mode is called **anonymous access type**
+* The access mode is called :dfn:`anonymous access type`
 
    - Anonymous access is implicitly general (no need for :ada:`all`)
 

--- a/courses/fundamentals_of_ada/160_genericity.rst
+++ b/courses/fundamentals_of_ada/160_genericity.rst
@@ -71,7 +71,7 @@ The Notion of a Pattern
 Solution: Generics
 --------------------
 
-* A generic unit is a unit that does not exist
+* A :dfn:`generic unit` is a unit that does not exist
 * It is a pattern based on properties
 * The instantiation applies the pattern to certain parameters
 
@@ -194,7 +194,7 @@ Generic Types Parameters (1/2)
          type T3 is limited private; -- can be limited
       package Parent is [...]
 
-* The actual parameter must provide at least as many properties as the generic contract
+* The actual parameter must provide at least as many properties as the :dfn:`generic contract`
 
 --------------------------------
 Generic Types Parameters (2/2)

--- a/courses/fundamentals_of_ada/170_tagged_derivation.rst
+++ b/courses/fundamentals_of_ada/170_tagged_derivation.rst
@@ -44,7 +44,7 @@ Object-Oriented Programming With Tagged Types
 
 * Child types can add new components (*attributes*)
 * Object of a child type can be **substituted** for base type
-* Primitive (*method*) can **dispatch at runtime** depending on the type at call-site
+* Primitive (*method*) can :dfn:`dispatch` **at runtime** depending on the type at call-site
 * Types can be **extended** by other packages
 
     - Casting and qualification to base type is allowed
@@ -151,10 +151,10 @@ Primitives
 
 * Child **cannot remove** a primitive
 * Child **can add** new primitives
-* **Controlling parameter**
+* :dfn:`Controlling parameter`
 
     - Parameters the subprogram is a primitive of
-    - For tagged types, all should have the **same type**
+    - For :ada:`tagged` types, all should have the **same type**
 
    .. code:: Ada
 
@@ -210,7 +210,7 @@ Tagged Aggregate
 
        V : Child := (F1 => 0, F2 => 0);
 
-* For **private types** use **aggregate extension**
+* For **private types** use :dfn:`aggregate extension`
 
     - Copy of a parent instance
     - Use :ada:`with null record` absent new fields

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -35,7 +35,7 @@ Introduction
 Introduction
 --------------
 
-* `'Class` operator to categorize classes of types
+* :ada:`'Class` operator to categorize :dfn:`classes of types`
 * Type classes allow dispatching calls
 
    - Abstract types

--- a/courses/fundamentals_of_ada/190_exceptions.rst
+++ b/courses/fundamentals_of_ada/190_exceptions.rst
@@ -58,7 +58,7 @@ Rationale for Exceptions
 Semantics Overview
 --------------------
 
-* Exceptions become active by being *raised*
+* Exceptions become active by being :dfn:`raised`
 
    - Failure of implicit language-defined checks
    - Explicitly by application
@@ -74,7 +74,7 @@ Semantics Overview
 * Normal execution abandoned when they occur
 
    - Error processing takes over in response
-   - Response specified by **exception handlers**
+   - Response specified by :dfn:`exception handlers`
    - *Handling the exception* means taking action in response
    - Other threads need not be affected
 


### PR DESCRIPTION
This PR adds definitions to the fundamental Ada classes (not adv or spec).
I added a definition under the following conditions: the term is new in the course, it is related to the class, it is defined in the RM, it can be understood from the paragraph or slides that follow.

I also changed some minor things: adding a definition for representation as "the memory-layout of an **object** of the type" (oversimplified but it gets the point accross); and making an element bold and a "tagged" as `:ada:`
