### PR TITLE
Task: adv and simple: fix, use named task tasks by default

### DIFF
--- a/courses/fundamentals_of_ada/240_tasking.rst
+++ b/courses/fundamentals_of_ada/240_tasking.rst
@@ -299,7 +299,7 @@ Task Scope
    .. code:: Ada
 
       package P is
-         task T;
+         task type T;
       end P;
 
       package body P is
@@ -309,6 +309,8 @@ Task Scope
                Put_Line ("tick");
             end loop;
          end T;
+
+         Task_Instance : T;
       end P;
 
 ========================

--- a/courses/fundamentals_of_ada/adv_240_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_240_tasking.rst
@@ -41,7 +41,7 @@ A Simple Task
    .. code:: Ada
 
       procedure Main is
-         task T;
+         task type T;
          task body T is
          begin
             loop
@@ -291,7 +291,7 @@ Quiz
 
       with Ada.Text_IO; use Ada.Text_IO;
       procedure Main is
-         task T is
+         task type T is
             entry Hello;
             entry Goodbye;
          end T;
@@ -589,7 +589,7 @@ Task Scope
    .. code:: Ada
 
       package P is
-         task T;
+         task type T;
       end P;
 
       package body P is
@@ -599,6 +599,8 @@ Task Scope
                Put_Line ("tick");
             end loop;
          end T;
+
+         Task_Instance : T;
       end P;
 
 ------------------------------
@@ -957,7 +959,7 @@ Setting Task Priority
 
 .. code:: Ada
 
-  task T
+  task type T
      with Priority => <priority_level>
      is ...
 
@@ -1022,9 +1024,9 @@ Abort Statements
    .. code:: Ada
 
       procedure Main is
-         task T;
+         task type T;
 
-         task T is
+         task body T is
          begin
             loop
                delay 1.0;


### PR DESCRIPTION
Use `task type T` instead of `task T` for ease of understanding.
Exception are where it makes sense: for brievity, or when explaining anonymous task types.

Also fixes a type where the `task body` was incorrectly declared.
