### PR TITLE
Polymorphism: fix wrong sentence, and tagged declarations

### DIFF
--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -196,7 +196,7 @@ Relation to Primitives
 
    Ada 2012
 
-* Warning: Subprograms with parameter of type `T'Class` are primitives of `T'Class`, not `T`
+* Warning: Subprograms with parameter of type `T'Class` are not primitives of `T`
 
       .. code:: Ada
 

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -200,7 +200,7 @@ Relation to Primitives
 
       .. code:: Ada
 
-         type Root is null record;
+         type Root is tagged null record;
          procedure P (V : Root'Class);
          type Child is new Root with null record;
          -- This does not override P!
@@ -242,7 +242,7 @@ Calls on class-wide types (1/3)
 
 .. code:: Ada
 
-   type Root is null record;
+   type Root is tagged null record;
    procedure P (V : Root);
 
    type Child is new Root with null record;
@@ -446,7 +446,7 @@ Multiple dispatching operands
 
    .. code:: Ada
 
-      type Root is null tagged record;
+      type Root is tagged null record;
       procedure P (Left : Root; Right : Root);
       type Child is new Root with null record;
       overriding procedure P (Left : Child; Right : Child);
@@ -478,7 +478,7 @@ Special case for equality
 
 .. code:: Ada
 
-   type Root is null tagged record;
+   type Root is tagged null record;
    function "=" (L : Root; R : Root) return Boolean;
    type Child is new Root with null record;
    overriding function "=" (L : Child; R : Child) return Boolean;

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -133,8 +133,8 @@ Testing the type of an object
                     -- Child_Class'Tag  = Child'Tag
 
    B1 : Boolean := Parent_Class_1 in Parent'Class;       -- True
-   B2 : Boolean := Parent_Class_1'Tag = Child'Class'Tag; -- False
-   B3 : Boolean := Child_Class'Tag = Parent'Class'Tag;   -- False
+   B2 : Boolean := Parent_Class_1'Tag = Child'Tag; -- False
+   B3 : Boolean := Child_Class'Tag = Parent'Tag;   -- False
    B4 : Boolean := Child_Class in Child'Class;           -- True
 
 ----------------


### PR DESCRIPTION
Fix a wrong sentence "is a primitive of `T'Class`": Class-wide cannot have primitives see RM 3.4-4
Fix tagged types declarations
