### PR TITLE
Original SPARK course minor reformat

### DIFF
--- a/contrib/rst_files_with_prelude.txt
+++ b/contrib/rst_files_with_prelude.txt
@@ -1,4 +1,5 @@
 courses/fundamentals_of_ada/*.rst
+courses/spark_for_ada_programmers/*.rst
 courses/advanced_exception_analysis/*.rst
 courses/gnatcheck/*.rst
 courses/codepeer/*.rst

--- a/courses/spark_for_ada_programmers/010_course_overview.rst
+++ b/courses/spark_for_ada_programmers/010_course_overview.rst
@@ -1,7 +1,31 @@
-
 *****************
 Course Overview
 *****************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==================
 A Little History

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -66,7 +66,7 @@ Formal Methods
    - We cannot produce a **complete**, correct formal specification
    - Not everything lends itself to formal specification
 
-      + :ada:`generic`, unchecked Ada, :ada:`with Import`...
+      + :ada:`generic`, :ada:`Ada.Unchecked_Conversion`, :ada:`with Import`...
 
 * Can prove extremely useful properties for portions of programs
 * Allow **combined** proof and test

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -66,7 +66,7 @@ Formal Methods
    - We cannot produce a **complete**, correct formal specification
    - Not everything lends itself to formal specification
 
-      + :ada:`generic`, :ada:`Ada.Unchecked_Conversion`, :ada:`with Import`...
+      + :ada:`generic`, :ada:`with Import`...
 
 * Can prove extremely useful properties for portions of programs
 * Allow **combined** proof and test

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -393,7 +393,7 @@ Allow Safely Removing Run-Time Checks
 Removing Run-Time Checks In SPARK
 -----------------------------------
 
-* SPARK allows proof of absence of run-time errors
+* SPARK allows **proof** of absence of run-time errors
 
    - Language-defined and user-defined checks
 
@@ -414,21 +414,21 @@ Objective: Functional Correctness
 
 * Contracts for functional correctness can be executed...
 
-   - Executable specifications can stand for test oracles
-   - If they are checked during integration testing, they may replace unit testing
-   - They are more maintainable than comments
+   - Executable specifications can stand for **test oracles**
+   - If they are checked during integration testing, they may **replace** unit testing
+   - They are more **maintainable** than comments
 
 * ... as well as formally proven
 
-   - Formal proof verifies the program on all possible inputs
-   - Verification can be done earlier in the development, before bodies are implemented
+   - Formal proof verifies the program on **all possible inputs**
+   - Verification can be done **earlier** in the development, before bodies are implemented
 
 ---------------------------------------
 Proving Arbitrary Boolean Properties
 ---------------------------------------
 
-* Proof of functional correctness verifies compliance with a specification
-* Specification may extend beyond requirements for program integrity (i.e., absence of run-time errors)
+* Proof of functional correctness verifies **compliance** with a specification
+* Specification may extend beyond requirements for **program integrity** (i.e., absence of run-time errors)
 
    - Arbitrary properties: derived requirements, etc.
 
@@ -507,7 +507,10 @@ Objective: Correct Components Integration
 
    - A subprogram, a unit, or a set of units
 
-* Even if components are verified individually, their combination may still fail because of unforeseen interactions or design problems
+* Even if components are verified individually, their **combination** may still fail
+
+   - Unforeseen interactions or design problems
+
 * You can specify exactly the inputs and outputs of each subprogram
 
    - Data dependency contracts
@@ -522,11 +525,11 @@ Objective: Correct Components Integration
 Components Integration: Defensive Code
 ----------------------------------------
 
-* Code that checks proper caller requirements
+* Code that checks proper **caller requirements**
 
    - E.g., cannot call `Push` on a full `Stack` object
 
-* You can replace defensive code with preconditions
+* You can **replace** defensive code with preconditions
 * Preconditions help component integration by proving callers adhere to called unit requirements
 
 ------------------------------------------------
@@ -556,18 +559,18 @@ Components Integration: Defensive Code Example
 Objective: Combining Proof and Testing
 ----------------------------------------
 
-* Some degree of testing is unavoidable
+* Some degree of testing is **unavoidable**
 
    - Social/legal reasons (Would you fly in an untested airplane?)
    - Limitations of formal proofs
    - Use of other, unverifiable languages along with SPARK
 
-* Typically, infeasible to test every possible case
+* Typically, **infeasible** to test **every** possible case
 
    - Huge number of cases, some unknown
    - Is deployment environment available? (e.g., Mars rovers)
 
-* Hit theoretical limits at extreme reliability levels
+* Hits theoretical limits at extreme reliability levels
 
    - *Butler, Ricky W.; Finelli, George B.* "The Infeasibility of Quantifying the Reliability of Life-critical Real-time Software"
 
@@ -575,16 +578,16 @@ Objective: Combining Proof and Testing
 Combined Proof and Test
 -------------------------
 
-* Combined proof and comprehensive testing is too expensive
+* Combined proof and **comprehensive** testing is **too expensive**
 
    - Comprehensive testing is already too expensive
 
-* Combined proof and selective testing can be less expensive than comprehensive testing alone
+* Combined proof and **selective** testing can be less expensive than comprehensive testing **alone**
 
-   - Only test things that cannot be proved (i.e., some unit tests)
-   - Integration testing will remain vital
+   - Only test things that **cannot be proved** (i.e., some unit tests)
+   - **Integration** testing will **remain vital**
 
-* Goal is to reach a level of confidence as good as the level reached by testing alone
+* Goal is to reach a **level of confidence** as good as the level reached by testing alone
 * Industrial use
 
    - E.g., Airbus for avionics software, NVIDIA for automotive software, etc.
@@ -607,11 +610,11 @@ Formal Methods and SPARK Summary
 
    - Especially so for high-integrity software
 
-* SPARK does not abolish complexity or difficulty
+* SPARK does **not** abolish complexity or difficulty
 
-   - But it does make it possible to reason about them!
+   - But it does make it **possible to reason** about them!
 
-* SPARK tools can prove extremely valuable properties
-* No silver bullets, but far better costs and quality are possible
+* SPARK tools can prove extremely valuable **properties**
+* **No silver bullets**, but far better costs and quality are possible
 
    - Demonstrated by real projects

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -189,8 +189,8 @@ Objectives of Using SPARK
 
 * Provide a safe coding subset
 * Address both data and control coupling
-* Prove absence of run-time errors (AoRTE)
-* Prove functional correctness
+* Prove absence of run-time errors (:dfn:`AoRTE`)
+* Prove **functional correctness**
 * Prove components integration
 * Support combined proof and unit testing
 
@@ -198,16 +198,16 @@ Objectives of Using SPARK
 A Brief Terminology Introduction
 ----------------------------------
 
-* **Contracts** are parts of specifications attached to program entities like subprograms
-* **Data dependency** contracts specify global data that a subprogram is allowed to read and/or write
-* **Flow dependency** contracts specify how a subprogram's outputs depend on its inputs
-* **Precondition** contracts specify caller constraints
+* :dfn:`Contracts` are parts of specifications attached to program entities like subprograms
+* :dfn:`Data dependency` contracts specify global data that a subprogram is allowed to **read and/or write**
+* :dfn:`Flow dependency` contracts specify how a subprogram's **outputs** depend on its **inputs**
+* :dfn:`Precondition` contracts specify caller **constraints**
 
-   - E.g., don't call `Push` on a full stack
+   - E.g., don't call :ada:`Push` on a full stack
 
-* **Postcondition** contracts specify guarantees by implementations
+* :dfn:`Postcondition` contracts specify **guarantees** by implementations
 
-   - E.g., after `Push` returns, the stack is not empty
+   - E.g., after :ada:`Push` returns, the stack is not empty
 
 -------------------------
 SPARK Contract Examples
@@ -236,15 +236,15 @@ SPARK Contract Examples
 Objective: Safe Coding Subset
 -------------------------------
 
-* Exclusion of unsafe features
+* Exclusion of **unsafe** features
 
-   - Constructs that preclude analysis
-   - Constructs that are likely to introduce errors
+   - Constructs that **preclude** analysis
+   - Constructs that are **likely** to introduce **errors**
 
       + Functions with side-effects (illustrated later)
       + Others...
 
-* Detection of errors in earlier lifecycle phases
+* Detection of errors in **earlier** lifecycle phases
 
    - Use of uninitialized variables
    - Problems due to parameter aliasing (illustrated later)
@@ -254,17 +254,17 @@ Objective: Safe Coding Subset
 Objective: Data And Control Coupling
 --------------------------------------
 
-* **Data coupling**
+* :dfn:`Data coupling`
 
-   - "The dependence of a software component on data not exclusively under the control of that software component"
+   - "The dependence of a software component on data **not exclusively** under the control of that software component"
 
-* **Control coupling**
+* :dfn:`Control coupling`
 
-   - "The manner or degree by which one software component influences the execution of another software component"
+   - "The manner or degree by which one software component influences the **execution** of another software component"
 
-* Vital to assessing impact of code changes
-* Vital part of security measures, ensuring data only go where intended
-* Typically required for project certification
+* Vital to assessing **impact** of code changes
+* Vital part of **security measures**, ensuring data only go where intended
+* Typically **required** for project **certification**
 
 .. container:: speakernote
 

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -1,8 +1,31 @@
-
 **************************
 Formal Methods and SPARK
 **************************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction
@@ -12,17 +35,18 @@ Introduction
 High-Integrity Software
 -------------------------
 
-* Has reliability as the most important requirement
+* Has **reliability** as the most important requirement
 
    - More than cost, time-to-market, etc.
 
-* Must be known to be reliable before being deployed
+* Must be known to be reliable **before** being deployed
 
    - With extremely low failure rates, e.g., 1 in 10:superscript:`9` hours (114,080 years)
    - Testing is insufficient and/or infeasible for such rates
 
-* Is not necessarily safety-critical
+* Is **not** necessarily safety-critical
 
+   - Could be *mission*-critical
    - E.g., satellites and remote exploration vehicles
    - E.g., financial systems
 
@@ -36,17 +60,19 @@ Rationale for Formal Analysis
 Formal Methods
 ----------------
 
-* Are a sufficient and cost-effective approach to show reliability prior to deployment
-* Are incapable of proving entire programs correct
+* **Sufficient** and **cost-effective** approach to show reliability **prior** to deployment
+* Are **not** capable of proving entire programs correct
 
-   - We cannot produce a complete, correct formal specification
+   - We cannot produce a **complete**, correct formal specification
    - Not everything lends itself to formal specification
 
+      + :ada:`generic`, unchecked Ada, :ada:`with Import`...
+
 * Can prove extremely useful properties for portions of programs
-* Allow combined proof and test
+* Allow **combined** proof and test
 
    - You don't have to test that which has been proven
-   - Or your tests will pass the first time
+   - Else your tests will pass the first time
    - Language capabilities help with testing
 
 .. container:: speakernote
@@ -78,9 +104,7 @@ Language Facilitates Proof and Test
 * The GNAT compiler has specific support options
 
    - Additional aliasing detection beyond Ada RM requirements
-
    - Additional data initialization and validity checks beyond Ada RM requirements
-
    - See the SPARK User's Guide for more details
 
 * Unit test tool :toolname:`GNATtest` makes testing easier

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -163,13 +163,15 @@ Math Hidden Behind the Tools
 
 * Typical for engineering disciplines
 
-   - Engineer working with tool can ignore details of heavy-duty math required
+   - Tool abstracts the **heavy-duty** math required
+   - User can focus on **abstracted** problems
 
 * This is a simulation of the NASA Space Launch System
 
-   - Shock wave (colored by pressure) is shown at front of vehicle
-   - Farther back, booster separation-motor plumes are colored by Mach number.
-   - Engineers can visualize issues without knowing how visualization is created
+   - Shock wave (colored by **pressure**) visible at the front of vehicle
+   - Farther back, booster separation-motor plumes are colored by **Mach number**
+   - Tool takes care of creating the **visualization**
+   - Engineers can focus on issues **visually**
 
 .. image:: rocket_launch_shock_wave.png
    :width: 30%

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -99,12 +99,12 @@ Combining Proof and Test - Cost Benefit
 Language Facilitates Proof and Test
 -------------------------------------
 
-* Proof contracts are executable, not just comments
-* Thus proof contracts can be checked at run-time with an error raised when a check fails
+* Proof contracts are **executable**, not just comments
+* Thus proof contracts can be **checked at run-time** with an error raised when a check fails
 * The GNAT compiler has specific support options
 
-   - Additional aliasing detection beyond Ada RM requirements
-   - Additional data initialization and validity checks beyond Ada RM requirements
+   - Additional **aliasing detection** beyond Ada RM requirements
+   - Additional data **initialization and validity** checks beyond Ada RM requirements
    - See the SPARK User's Guide for more details
 
 * Unit test tool :toolname:`GNATtest` makes testing easier
@@ -124,7 +124,7 @@ SPARK
 
    - Hides the math from users
 
-* Uses statically provable contracts + testing
+* Uses **statically provable** contracts + testing
 * Based on Ada
 
 --------------------------

--- a/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/020_formal_methods_and_spark.rst
@@ -127,6 +127,10 @@ SPARK
 * Uses **statically provable** contracts + testing
 * Based on Ada
 
+   - Strict subset of Ada **2022**
+   - Compiled SPARK is **binary-compatible** with Ada
+   - Can be **linked** directly to Ada
+
 --------------------------
 The Programming Language
 --------------------------
@@ -139,7 +143,7 @@ The Programming Language
 * Excluded from SPARK:
 
    - Aliasing data-structures obtained using access types
-   - Expressions (including function calls) with side-effects
+   - Expressions (including function calls) with **side-effects**
    - Aliasing of names
    - Backwards goto statements
    - Controlled types
@@ -269,23 +273,28 @@ Objective: Data And Control Coupling
 How SPARK Addresses Data Coupling
 -----------------------------------
 
-* Global data dependency contracts specify global inputs and outputs, thus identifying data not exclusively under unit's control
+* Global data dependency contracts specify **global inputs and outputs**
 
-      .. code:: Ada
+    - :ada:`with Global`
+    - Identifying data **not exclusively** under unit's control
 
-         procedure Add_To_Total (X : in Integer) with
-            Global => (In_Out => Total);
+    .. code:: Ada
 
-   - Total is a global variable both read and written
+        procedure Add_To_Total (X : in Integer) with
+           Global => (In_Out => Total);
 
-* Flow dependency contracts specify exactly how data influence subprogram output values
+   - :ada:`Total` is an :ada:`in out` global variable: both **read and written**
 
-      .. code:: Ada
+* Flow dependency contracts specify exactly how data influence subprogram **output values**
 
-         procedure Add_To_Total (X : in Integer) with
-            Depends => (Total => (Total, X));
+    - :ada:`with Depends`
 
-   - Value of output `Total` depends on inputs `Total` and `X`
+    .. code:: Ada
+
+        procedure Add_To_Total (X : in Integer) with
+           Depends => (Total => (Total, X));
+
+   - Value of output :ada:`Total` depends on inputs :ada:`Total` and :ada:`X`
 
 --------------------------------------
 How SPARK Addresses Control Coupling
@@ -293,19 +302,21 @@ How SPARK Addresses Control Coupling
 
 * Flow dependency contracts specify the shared data potentially written by a subprogram
 
-   - Those data values affect the execution, otherwise a message
+    - Those data values **will** affect the execution (otherwise emit a message)
 
-      .. code:: Ada
+    .. code:: Ada
 
-         procedure Add_To_Total (X : in Integer) with
-            Depends => (Total => (Total, X));
+        procedure Add_To_Total (X : in Integer) with
+           Depends => (Total => (Total, X));
 
-* Functional contracts specify the behavior of a subprogram, which defines how it "influences the execution of another software component"
+* Functional contracts specify the behavior of a subprogram
 
-      .. code:: Ada
+    - How it "influences the execution of another software component"
 
-         procedure Add_To_Total (X : in Integer) with
-            Pre => X >= 0 and then Total <= Integer'Last - X;
+    .. code:: Ada
+
+        procedure Add_To_Total (X : in Integer) with
+           Pre => X >= 0 and then Total <= Integer'Last - X;
 
 .. container:: speakernote
 

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -529,12 +529,12 @@ Meaning of :ada:`SPARK_Mode` Argument
 The Pragma Will Be Used Often
 -------------------------------
 
-* Because there is no syntax defined for an aspect at several points in the language
+* Because there is **no syntax** defined for an aspect at several points in the language
 
    - E.g., optional private part of a package or task declaration
 
-* Can be used anywhere the aspect can be used
-* Must appear first (so that it applies to all of it), except for other pragmas if any
+* Can be used **anywhere** the aspect can be used
+* **Must appear first** (so that it applies to all of it), except for other pragmas if any
 
 ---------------------------------
 Meaning of "Corresponding Code"
@@ -557,12 +557,12 @@ Mixing SPARK and Ada
 Identifying SPARK Code
 ------------------------
 
-* `SPARK_Mode` (aspect or pragma)
+* :ada:`SPARK_Mode` (aspect or pragma)
 * Specifies whether code is intended to be SPARK
-* It should be added to every unit to be analyzed
+* It **should** be added to **every unit** to be analyzed
 
-   - or can be set globally using a configuration pragma
-   - note that with'ed units default to `Auto`
+   - or can be set **globally** using a **configuration pragma**
+   - note that :ada:`with`'ed units default to :ada:`Auto`
 
       + Up to :toolname:`GNATprove` to determine whether or not a given construct is in SPARK
 
@@ -570,7 +570,7 @@ Identifying SPARK Code
 Setting `SPARK_Mode`
 ------------------------
 
-* `SPARK_Mode` can be `On` or `Off` for
+* :ada:`SPARK_Mode` can be :ada:`On` or :ada:`Off` for
 
    - visible part of package specification
    - private part of package specification
@@ -579,14 +579,14 @@ Setting `SPARK_Mode`
    - subprogram specification
    - subprogram body
 
-* If SPARK mode is `Off` for a package or subprogram then it cannot be switched `On` for a later part of that package or subprogram
-* Note that a package spec and its corresponding body are not the same construct!
+* If SPARK mode is :ada:`Off` for a package or subprogram then it **cannot** be switched :ada:`On` for a later part of that package or subprogram
+* Note that a package spec and its corresponding body are **not** the same construct!
 
    - Mode for the spec does not set mode for the body
 
---------------------------------------
-"Later" Parts Can Be Turned `Off`
---------------------------------------
+----------------------------------------
+"Later" Parts Can Be Turned :ada:`Off`
+----------------------------------------
 
 .. code:: Ada
 
@@ -611,18 +611,18 @@ Setting `SPARK_Mode`
 Two General Principles for Mixing
 -----------------------------------
 
-* SPARK code must only reference SPARK entities
+* SPARK code **must** only reference SPARK entities
 
-   - But a SPARK declaration may have a non-SPARK completion
+   - But a SPARK declaration **may** have a non-SPARK **completion**
 
-* SPARK code is assumed to enclose SPARK code
+* SPARK code is **assumed** to enclose SPARK code
 
-   - Unless enclosed code is explicitly marked as non-SPARK
+   - **Unless** enclosed code is **explicitly** marked as non-SPARK
 
 * The word **reference** is key:
 
    - The spec is what is referenced (i.e., the declaration) so the completion needs not be in SPARK
-   - A non-SPARK package can be with'ed by SPARK code as long as the referenced parts comply with the SPARK subset
+   - A non-SPARK package **can** be :ada:`with`'ed by SPARK code as long as the referenced parts comply with the SPARK subset
 
 ---------------------------------
 Common Mixed SPARK/Ada Approach
@@ -653,7 +653,7 @@ Common Mixed SPARK/Ada Approach
 Can Verify Selected Subprograms
 ---------------------------------
 
-* Some specs with `SPARK_Mode` `On`, others `Off`
+* Some specs with :ada:`SPARK_Mode` :ada:`On`, others :ada:`Off`
 
    - Modes determine what is allowed in the specs
 
@@ -678,7 +678,7 @@ Can Verify Selected Subprograms
 SPARK Code Cannot Use Mode `Off` Code
 -----------------------------------------
 
-* That is, when spec is explicitly marked as `Off`
+* That is, when spec is explicitly marked as :ada:`Off`
 
 .. code:: Ada
 
@@ -696,7 +696,7 @@ SPARK Code Cannot Use Mode `Off` Code
 Subprogram Specs Are Sufficient
 ---------------------------------
 
-* `SPARK_Mode` `On` for declaration, `Off` for body
+* :ada:`SPARK_Mode` :ada:`On` for declaration, :ada:`Off` for body
 * SPARK callers "see" only SPARK, thus callable
 
 .. code:: Ada
@@ -744,9 +744,9 @@ Mode `Off` for Bodies Allows Full Ada
 If Implementing a SPARK Spec in Full Ada
 ------------------------------------------
 
-* The user must verify SPARK properties
+* The user **must** verify SPARK properties
 
-   - Failure to do so may invalidate entire :toolname:`GNATprove` analysis of SPARK caller code, silently!
+   - Failure to do so may invalidate **entire** :toolname:`GNATprove` analysis of SPARK caller code, **silently**!
 
 .. code:: Ada
 
@@ -769,14 +769,14 @@ If Implementing a SPARK Spec in Full Ada
 What If the Mode Is Not Explicitly Set?
 -----------------------------------------
 
-* I.e., `SPARK_Mode` aspect/pragma is not applied
+* I.e., :ada:`SPARK_Mode` aspect/pragma is not applied
 
    - Neither in the unit in question nor globally
 
-* The mode is then said to be `Auto`
-* In this mode :toolname:`GNATprove` only checks subset conformance on declarations of entities actually referenced in SPARK code
+* The mode is then said to be :ada:`Auto`
+* In this mode :toolname:`GNATprove` only checks subset conformance on **declarations** of entities actually **referenced** in SPARK code
 
-   - Their implementations are not analyzed by :toolname:`GNATprove`
+   - Their **implementations** are **not** analyzed by :toolname:`GNATprove`
 
 * Allowed for Ada packages named in :ada:`with` clauses
 
@@ -785,9 +785,9 @@ What If the Mode Is Not Explicitly Set?
 
 * Such Ada code can still be used with SPARK code
 
----------------------------------
-Auto `SPARK_Mode` Example
----------------------------------
+--------------------------------
+Auto :ada:`SPARK_Mode` Example
+--------------------------------
 
 .. code:: Ada
 
@@ -805,9 +805,9 @@ Auto `SPARK_Mode` Example
       ...
    end IO;
 
-------------------------------------------
-Example Usage of Auto `SPARK_Mode`
-------------------------------------------
+-----------------------------------------
+Example Usage of Auto :ada:`SPARK_Mode`
+-----------------------------------------
 
 .. code:: Ada
 
@@ -832,9 +832,9 @@ Example Usage of Auto `SPARK_Mode`
 
    Put Line is not rejected because its spec is SPARK conformant.
 
------------------------------------------
-Setting Default `SPARK_Mode` Globally
------------------------------------------
+--------------------------------------------
+Setting Default :ada:`SPARK_Mode` Globally
+--------------------------------------------
 
 * Achieved via *configuration pragma* usage
 
@@ -842,19 +842,19 @@ Setting Default `SPARK_Mode` Globally
    - Applies to entire partition (program), by definition
    - Illustrated later...
 
-* If the argument is `Off` then Ada is assumed
+* If the argument is :ada:`Off` then **Ada is assumed**
 
-   - Only code explicitly marked `On` is assumed to be in SPARK
-   - Appropriate when only a very small amount is in SPARK
+   - **Only** code explicitly marked :ada:`On` is assumed to be in SPARK
+   - Appropriate when only a **very small** amount is in **SPARK**
 
-* If the argument is `On` then SPARK is assumed
+* If the argument is :ada:`On` then **SPARK is assumed**
 
-   - Only code explicitly marked as `Off` is assumed to be in Ada
-   - Appropriate when only a small amount is in Ada
+   - **Only** code explicitly marked as `Off` is assumed to be in Ada
+   - Appropriate when only a **small amount** is in **Ada**
 
------------------------------------------
-When `SPARK_Mode` Is Globally `Off`
------------------------------------------
+-----------------------------------------------------
+When :ada:`SPARK_Mode` Is Globally :ada:`Off` (1/2)
+-----------------------------------------------------
 
 .. code:: Ada
 
@@ -866,7 +866,7 @@ When `SPARK_Mode` Is Globally `Off`
       ...
    end Z;
 
-* You cannot turn it on in a later part without also turning it on in the earlier part
+* You **cannot** turn it on in a later part without also turning it on in the earlier part
 
    .. code:: console
 
@@ -876,11 +876,11 @@ When `SPARK_Mode` Is Globally `Off`
      z.ads:7:23: value Off was set for SPARK_Mode on "Z" at
         config.adc:1
 
----------------------------------------------
-When `SPARK_Mode` Is Globally `Off` (2)
----------------------------------------------
+-----------------------------------------------------
+When :ada:`SPARK_Mode` Is Globally :ada:`Off` (2/2)
+-----------------------------------------------------
 
-* Only the pragma can turn it on for a unit
+* **Only** the :ada:`pragma` can turn it on for a unit
 
 .. code:: Ada
 
@@ -952,9 +952,9 @@ SPARK Key Tools
 
 .. image:: gnatprove-output-options.png
 
----------------------------------------
-Analysis Summary File "gnatprove.out"
----------------------------------------
+-------------------------------------------------
+Analysis Summary File :filename:`gnatprove.out`
+-------------------------------------------------
 
 * Located in :filename:`gnatprove/` under project object dir
 * An overview of results for all checks in project

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -219,7 +219,7 @@ What Is a Side-Effect?
    modifying a global in a function is illegal SPARK
 
 ----------------------------------------
-Why not Side Effects - Writing Globals
+Why no Side Effects - Writing Globals
 ----------------------------------------
 
 .. code:: Ada
@@ -245,9 +245,9 @@ Why not Side Effects - Writing Globals
    - If left parameter evaluated first, X=0, Y=1
    - If right parameter evaluated first, X=1, Y=1
 
------------------------------------------------
-Why not Side Effects - `in out` Formals (1/2)
------------------------------------------------
+----------------------------------------------------
+Why no Side Effects - :ada:`in out` Formals (1/2)
+----------------------------------------------------
 
 .. code:: Ada
 
@@ -267,9 +267,9 @@ Why not Side Effects - `in out` Formals (1/2)
    - If left parameter evaluated first, X=0, Y=1
    - If right parameter evaluated first, X=1, Y=1
 
------------------------------------------------
-Why not Side Effects - `in out` Formals (2/2)
------------------------------------------------
+----------------------------------------------------
+Why no Side Effects - :ada:`in out` Formals (2/2)
+----------------------------------------------------
 
 .. code:: Ada
 
@@ -302,14 +302,14 @@ Parameter Name Aliasing
 -------------------------
 
 * In terms of actual parameters and global variables
-* Occurs when there are multiple names for an actual parameter inside the subprogram body
+* Occurs when there are **multiple names** for an actual parameter inside the subprogram body
 
    - Global variable passed as actual parameter and referenced inside subprogram via global name
    - Same actual passed to more than one formal
    - Two actuals are overlapping array slices
    - One actual is contained within another actual
 
-* Can lead to code dependent on parameter-passing mechanism (another case of erroneous behavior)
+* Can lead to code **dependent** on parameter-passing mechanism (another case of **erroneous** behavior)
 
 -----------------------------------------
 Parameter Aliasing with Global Variable
@@ -362,19 +362,22 @@ Parameter Aliasing via Repeated Actuals
 Aliasing with Composite Data Types
 ------------------------------------
 
-* Arrays
+* :ada:`array`
 
-   - Array elements can be indexed dynamically so this is not allowed (because X and Y could be the same, and aliasing checks are done at flow analysis stage)
+   - Array elements can be indexed **dynamically** so this is **not allowed**
+
+      * :ada:`X` and :ada:`Y` **could** be the same
+      * Aliasing checks are done at **flow analysis** stage
 
       .. code:: Ada
 
          Swap (My_Array (X), My_Array (Y)); -- illegal
 
-   - In the future, these checks might be moved to the proof stage, allowing the tools to be less restrictive
+   - **In the future**, these checks might be moved to the **proof stage**, allowing the tools to be **less restrictive**
 
-* Records
+* :ada:`record`
 
-   - Aliasing of inputs is permitted if they do not overlap with outputs
+   - Aliasing of inputs is **permitted** if they **do not overlap** with outputs
    - Different fields of a record cannot overlap so this is allowed
 
       .. code:: Ada
@@ -385,10 +388,10 @@ Aliasing with Composite Data Types
 Parameter Aliasing Prevention In SPARK
 ----------------------------------------
 
-* Multiple output parameters must not be aliased
-* Input and output parameters must not be aliased, if there is possible interference
-* Output parameters must never be aliased with global variables referenced by the subprogram
-* Input parameters must not be aliased with global variables written by the subprogram, unless they are always passed by copy (reading is OK)
+* **Multiple output** parameters must **not** be aliased
+* **Input and output** parameters must not be aliased, if there is **possible interference**
+* **Output** parameters must **never** be aliased with **global variables** referenced by the subprogram
+* **Input** parameters must not be aliased with **global variables** written by the subprogram, **unless** they are always **passed by copy** (reading is OK)
 * Functions cannot have outputs (parameters or global variables) hence cannot introduce illegal aliasing
 
 ----------------------------
@@ -396,29 +399,29 @@ Data Initialization Policy
 ----------------------------
 
 * Modes on formal parameters and data dependency contracts have a stricter meaning than in Ada
-* Mode :ada:`in` (and global mode `Input`): the object should be completely initialized before the call
-* Mode :ada:`out` (and global mode `Output`): the object should be completely initialized before returning
-* Mode :ada:`in out` (and global mode `In_Out`): the object should be completely initialized before calling the subprogram
+* Mode :ada:`in` (and global mode :ada:`Input`): the object should be completely **initialized before the call**
+* Mode :ada:`out` (and global mode :ada:`Output`): the object should be completely **initialized before returning**
+* Mode :ada:`in out` (and global mode :ada:`In_Out`): the object should be completely **initialized before the call**
 
 -----------------------------------------
 Data Initialization Policy Consequences
 -----------------------------------------
 
-* All inputs must be completely initialized on entry
-* All outputs must be completely initialized on exit
-* All objects must be completely initialized when read
+* All **inputs** must be completely initialized **on entry**
+* All **outputs** must be completely initialized **on exit**
+* All **objects** must be completely initialized **when read**
 
-   - Except for record objects, provided those components that are read are initialized
-   - Above rule exception doesn't apply to array objects
+   - **Except** for :ada:`record` objects, provided those components that are read are initialized
+   - Above rule exception doesn't apply to :ada:`array` objects
 
-* A parameter or global variable partially written in a subprogram should be mode :ada:`in out`, not mode :ada:`out`
+* A parameter or global variable **partially written** in a subprogram should be mode :ada:`in out`, not mode :ada:`out`
 * :toolname:`GNATprove` will complain if policy is violated
 
 -------------------------------------------
 No Initialization Across Library Packages
 -------------------------------------------
 
-* In SPARK, package elaboration cannot initialize variables declared in other library packages
+* In SPARK, package elaboration **cannot** initialize variables declared in **other library** packages
 * In combination with other rules, prevents elaboration order issues
 
 .. code:: Ada
@@ -440,11 +443,11 @@ Thus The Term "Safe Subset"
 
 * A good idea even if you don't yet use all of SPARK
 
-   - Helpful for better coding practices in Ada
+   - Helpful for **better coding practices** in Ada
 
       + Reduces chances of errors
 
-   - Works for other languages as well
+   - Works for **other languages** as well
 
       + Even without language limitations, useful for reducing complexity of code
       + Enforce through standards rather than compiler
@@ -477,14 +480,14 @@ Various Other Differences from Ada
 Mixing SPARK and Ada
 ----------------------
 
-* May be necessary for new code
+* May be necessary for **new code**
 
    - A prohibited construct may be "best" approach
 
-* May be necessary for reusing existing code
+* May be necessary for reusing **existing code**
 
    - Prohibited constructs may require extensive changes
-   - May want to approach legacy code incrementally
+   - May want to approach legacy code **incrementally**
    - May have extensive reusable libraries
 
 * Allows verifying as much as possible of a code base
@@ -501,22 +504,22 @@ Identifying SPARK Code
 
 * Aspect and :ada:`pragma SPARK_Mode` specify whether code is intended to be in SPARK
 
-   - Argument values are `On` and `Off`
+   - Argument values are :ada:`On` and :ada:`Off`
 
 * Can be applied to individual units, or globally as a default
 * Absent the aspect/pragma, code is assumed to be full Ada
 
-------------------------------------
-Meaning of `SPARK_Mode` Argument
-------------------------------------
+---------------------------------------
+Meaning of :ada:`SPARK_Mode` Argument
+---------------------------------------
 
-* `On`
+* :ada:`On`
 
    - Corresponding code is required to be in SPARK
    - Corresponding code will be analyzed by :toolname:`GNATprove`
    - The default argument when no argument specified explicitly
 
-* `Off`
+* :ada:`Off`
 
    - Corresponding code can be in full Ada
    - Corresponding code will not be analyzed by :toolname:`GNATprove`

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -35,18 +35,18 @@ Introduction
 Static Verification Goals
 ---------------------------
 
-* Deep, i.e., tells you something useful
-* Sound
+* **Deep**, i.e., tells you something useful
+* **Sound**
 
-   - Presents no false negatives
+   - Presents **no false negatives**
    - If it does not indicate a problem, there is no problem in the analyzed code
 
-* Complete
+* **Complete**
 
-   - With as few false alarms as possible
+   - With as **few false alarms** as possible
 
-* Fast
-* Modular and constructive, works on incomplete programs
+* **Fast**
+* **Modular** and **constructive**, works on incomplete programs
 
 =================
 Language Design
@@ -56,7 +56,7 @@ Language Design
 SPARK - A Brief History
 -------------------------
 
-* The SPARK language has continually evolved along with the major revisions of Ada
+* The SPARK language has **continually evolved** along with the major revisions of Ada
 
 |
 
@@ -78,17 +78,17 @@ Language Design Principles
 
 * DO-333 says:
 
-   - "...an analysis method can only be regarded as formal analysis if its determination of a property is sound. Sound analysis means that the method never asserts a property to be true when it is not true."
+   - "...an analysis method can only be regarded as **formal analysis** if its determination of a property is **sound**. Sound analysis means that the method **never** asserts a property **to be true when it is not** true."
 
 --------------------------------------
 Language Design Principles Explained
 --------------------------------------
 
-* "Unambiguous" - What does this mean in practice?
+* "Unambiguous" - What does this mean **in practice**?
 
-   - No erroneous behavior allowed.
-   - No unspecified language features.
-   - Limit implementation-defined features to as small a set as possible and allow these to be configured for a particular implementation.
+   - **No erroneous** behavior allowed.
+   - **No unspecified** language features.
+   - Limit implementation-defined features to as **small a set as possible** and allow these to be **configured** for a particular implementation.
 
 .. container:: speakernote
 

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -959,7 +959,7 @@ Analysis Summary File :filename:`gnatprove.out`
 * Located in :filename:`gnatprove/` under project object dir
 * An overview of results for all checks in project
 * Especially useful when results must be documented
-* Details in the UG *"How to View :toolname:`GNATprove` Output"*
+* Details in the UG *"How to View GNATprove Output"*
 
 |
 
@@ -972,9 +972,9 @@ Analysis Summary File :filename:`gnatprove.out`
 
 * Error Messages
 
-   - Indicate illegalities
+   - Indicate **illegalities**
    - E.g., SPARK subset violations and violations of flow analysis
-   - Processing cannot continue so cannot be suppressed
+   - Processing **cannot continue** so cannot be suppressed
 
       .. code:: console
 
@@ -984,7 +984,7 @@ Analysis Summary File :filename:`gnatprove.out`
 
    - Notify users of limitations of :toolname:`GNATprove` on some constructs
    - Prevent confusion regarding other output
-   - Can include the list of proved checks if requested
+   - Can include the **list of proved checks** if requested
 
       .. code:: console
 
@@ -996,7 +996,7 @@ Analysis Summary File :filename:`gnatprove.out`
 
 * Warning Messages
 
-   - Indicate suspicious situations, e.g., useless assignments
+   - Indicate **suspicious** situations, e.g., useless assignments
    - Prefixed with **warning:**
    - Can be suppressed with :ada:`pragma Warnings`
 
@@ -1006,9 +1006,9 @@ Analysis Summary File :filename:`gnatprove.out`
 
 * Check Messages
 
-   - Indicate potential problems affecting correctness
+   - Indicate **potential** problems affecting correctness
    - E.g., possible failing run-time checks or unproved contracts
-   - Prefixed with **low** or **medium** or **high**
+   - Prefixed with ``low``, ``medium``, or ``high``
    - Cannot be suppressed like warning messages
    - Can be individually justified with :ada:`pragma Annotate`
 
@@ -1032,11 +1032,11 @@ Analysis Summary File :filename:`gnatprove.out`
 
 * Selected by switch :command:`--mode=<mode>`
 
-   :check: Fast partial check for SPARK subset
-   :`check_all`: Full check for SPARK subset (e.g., side effects)
-   :flow: Flow mode
-   :prove: Proof mode
-   :all: ``check_all`` + flow + prove (default)
+   :``check``: Fast partial check for SPARK subset
+   :``check_all``: Full check for SPARK subset (e.g., side effects)
+   :``flow``: Flow mode
+   :``prove``: Proof mode
+   :``all``: ``check_all`` + ``flow`` + ``prove`` (**default**)
 
 ----------------------------------------------
 General :toolname:`GNATprove` Usage Workflow
@@ -1051,34 +1051,34 @@ General :toolname:`GNATprove` Usage Workflow
 
 * By default, absence of check messages |rightarrow| success
 
-   - Analysis is sound: guaranteed no mode-specific error in code analyzed
+   - Analysis is **sound**: guaranteed no mode-specific error in code analyzed
 
 * If rejected, change the code: fix or justify (if possible)
 
 ---------------------------------
-What Is Verified In "flow" Mode
+What Is Verified In ``flow`` Mode
 ---------------------------------
 
 * Code intended to be in SPARK is indeed in subset
-* With no SPARK-specific aspects (standard Ada), success means no reads of uninitialized data and no problematic aliasing
-* With Global aspects added, success means correct use of global data
-* With Depends aspects added, success means information flow for parameters and globals is as specified
+* With **no** SPARK-specific aspects (standard Ada), success |rightarrow| no reads of uninitialized data and no problematic aliasing
+* With :ada:`with Global`, success |rightarrow| correct use of global data
+* With :ada:`with Depends`, success |rightarrow| information flow for parameters and globals is as specified
 * If you get errors or check messages, change the code...
 * We will cover these aspects in detail
 
 ----------------------------------
-What Is Verified In "prove" Mode
+What Is Verified In ``prove`` Mode
 ----------------------------------
 
 * SPARK subset conformance
-* Success proves absence of run-time errors
+* Success proves **absence of run-time errors**
 
    - From Ada language-defined run-time checks
-   - From explicit raise statements
-   - From Assert pragmas
+   - From explicit :ada:`raise` statements
+   - From :ada:`pragma Assert`
    - But you will likely need to add some contracts to get there
 
-* With preconditions and postconditions, success proves those contracts always hold
+* With preconditions and postconditions, success proves those contracts **always** hold
 
    - Unit functionality, as expressed in postconditions
    - Any arbitrary boolean properties you specified
@@ -1089,17 +1089,17 @@ What Is Verified In "prove" Mode
 Using SPARK Features with :toolname:`GNATprove`
 -------------------------------------------------
 
-* Can start with only Ada and basic checking modes
+1. Can start with only Ada and basic checking modes
 
    - Nothing SPARK-specific
    - No Ada contracts required (but allowed)
    - :toolname:`GNATprove` only attempts to verify SPARK subset compliance
 
-* As contracts are added, invoke :toolname:`GNATprove` with more advanced analysis modes
+2. As contracts are added, invoke :toolname:`GNATprove` with more advanced analysis modes
 
    - Increases the strength of the properties proven (e.g., no buffer overflow, functional correctness)
 
-* Use a more advanced mode only after analysis at all lower modes is successful
+3. Use a more advanced mode only after analysis at all lower modes is successful
 
    - Higher modes' analyses depend on them (e.g., subset conformance, no uninitialized data is read)
    - Higher modes perform nearly all lower modes' analyses
@@ -1112,17 +1112,17 @@ Which Mode To Use?
 
    - E.g., invalid data initialization may invalidate proof
 
-* Thus make sure you pass flow analysis (using "flow" mode) before moving on to "proof" mode
-* Consider that mode "all" does all the necessary analyses and does them in the necessary order
+* Thus make sure you pass flow analysis (using ``flow`` mode) before moving on to ``proof`` mode
+* Consider that mode ``all`` does all the necessary analyses and does them in the necessary order
 
 ------------------------------------------
 :toolname:`GNATprove` Project File Usage
 ------------------------------------------
 
 * Apply the usual attributes to define source dirs, set compiler switches, and so on
-* Tool package `Prove` corresponds to :toolname:`GNATprove`
+* Tool package :ada:`Prove` corresponds to :toolname:`GNATprove`
 
-   - Use attribute `Proof_Switches` to apply tool-defined switches
+   - Use attribute :ada:`Proof_Switches` to apply tool-defined switches
 
 .. code:: Ada
 
@@ -1139,13 +1139,13 @@ Which Mode To Use?
      ...
    end SPARK_Dev;
 
------------------------------------------
-To Specify Default `SPARK_Mode` Value
------------------------------------------
+--------------------------------------------
+To Specify Default :ada:`SPARK_Mode` Value
+--------------------------------------------
 
-* Include pragma `SPARK_Mode` in a "configuration pragmas" file, with the chosen default value
-* The project file specifies path/name of this file via the `Global_Configuration_Pragmas` attribute
-* GPR file
+* Include :ada:`pragma SPARK_Mode` in a "configuration pragmas" file, with the chosen default value
+* The project file specifies path/name of this file via the :ada:`Global_Configuration_Pragmas` attribute
+* :filename:`p.gpr`
 
    .. code:: Ada
 
@@ -1157,7 +1157,7 @@ To Specify Default `SPARK_Mode` Value
          ...
       end P;
 
-* config.adc
+* :filename:`config.adc`
 
    .. code:: Ada
 
@@ -1197,7 +1197,7 @@ Basic :toolname:`GNAT Studio` Look and Feel
 .. container:: speakernote
 
    "all" = all provers
-   The "Examine *" menu entries also check for SPARK subset conformance.
+   The "Examine XXX" menu entries also check for SPARK subset conformance.
    Proof involves the Flow Analysis function as well.
 
 ------------------------------
@@ -1278,23 +1278,23 @@ FAQs
 
 * Why can't I find the "SPARK" menu?
 
-   - Check that :toolname:`GNATprove` is on your PATH
+   - Check that :toolname:`GNATprove` is on your ``PATH``
 
 -------------------------
 SPARK Language Benefits
 -------------------------
 
-* Amplifies the strengths of Ada
+* **Amplifies** the strengths of Ada
 
    - Truly complete specifications for subprograms etc.
 
-* Gives program source text a precise meaning
-* Guarantees freedom from certain classes of error
+* Gives program source text a **precise meaning**
+* Guarantees **freedom** from certain **classes of error**
 
    - Extremely important errors, such as buffer overflow
 
-* Simplifies early detection of other errors
-* Captures important design information in the code
+* Simplifies **early detection** of other errors
+* Captures important **design information** in the code
 
 --------------------------------------
 SPARK Language and Key Tools Summary
@@ -1302,13 +1302,13 @@ SPARK Language and Key Tools Summary
 
 * Restrictions are imposed on language constructs
 
-   - Some because their effects would defy formal analysis
-   - Others because analysis is feasible but not yet mature
-   - Some are always suspect (e.g., side-effects)
+   - Some because their effects would **defy** formal analysis
+   - Others because analysis is feasible but not yet **mature**
+   - Some are always **suspect** (e.g., side-effects)
 
-* Language subset is very large, most of Ada
+* Language subset is **very large**, most of Ada
 
-   - The subset is expanding over time
+   - The subset is **expanding** over time
 
 * Includes additional aspects not in Ada (yet)
 * Mixing with Ada allows flexibility and reuse

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -1,8 +1,31 @@
-
 **************************
 SPARK Language and Tools
 **************************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 =================
 Introduction

--- a/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
+++ b/courses/spark_for_ada_programmers/030_spark_language_and_tools.rst
@@ -106,10 +106,10 @@ Language Design Principles
 
    - SPARK 2014 is designed to be a **formal method** as defined by DO-333.
 
-* Support contract-based programming
+* Support **contract-based** programming
 
-   - For programmers to declare intent and responsibilities of different parts of the source code
-   - Support both static and dynamic verification of contracts
+   - For programmers to declare **intent and responsibilities** of different parts of the source code
+   - Support both **static and dynamic** verification of contracts
 
 --------------------
 The SPARK Language
@@ -117,15 +117,15 @@ The SPARK Language
 
 * Designed for static verification
 
-   - Completely unambiguous
-   - All implementation dependencies are made explicit
+   - Completely **unambiguous**
+   - All implementation **dependencies** are made **explicit**
    - All rule violations are detectable
-   - Formally defined
+   - Formally **defined**
    - Tool supported
 
-* Designed to enable reasoning rigorously about software
+* Designed to enable rigorous reasoning about software
 
-   - Nothing hidden, especially state dependencies
+   - **Nothing** hidden, especially state dependencies
 
 * Based on Ada's foundation for high reliability
 
@@ -146,7 +146,7 @@ A Simple Example of Verifiable Properties
       X := X + 1;
    end Increment;
 
-* These properties are proven (or not) for all possible cases
+* These properties are proven (or not) for **all possible cases**
 
 --------------------------------------------
 Verification Requires Construct Exclusions
@@ -154,23 +154,23 @@ Verification Requires Construct Exclusions
 
 * Design according to the SPARK design principles:
 
-   - Exclude language features difficult to specify/verify
-   - Eliminate sources of ambiguity
+   - **Exclude** language features **difficult** to specify/verify
+   - **Eliminate** sources of **ambiguity**
 
 * Exclusions
 
-   - Access types and values creating aliased data structures
+   - **Access** types and values creating **aliased** data structures
 
       + Note you don't need them nearly as much in Ada/SPARK
 
-   - Expressions (including function calls) with side effects
-   - Aliasing of names
-   - Backwards `goto` statements
+   - Expressions (including function calls) with **side effects**
+   - **Aliasing** of names
+   - Backwards :ada:`goto` statements
 
       + Can create loops, which require a specific treatment in formal verification
 
-   - Controlled types (complex control flow)
-   - Exception handlers (raising them is allowed)
+   - **Controlled** types (complex control flow)
+   - Exception **handlers** (raising them is allowed)
    - Tasking constructs other than in Ravenscar and Jorvik
 
 ======================
@@ -181,15 +181,14 @@ Language Limitations
 Functions May Not Have Side-Effects
 -------------------------------------
 
-* The analysis of SPARK programs relies on the property that expressions are free from side-effects
+* The analysis of SPARK programs relies on the property that **expressions are free from side-effects**
 
   - Side-effects in expressions lead to erroneous behavior
-
   - Not so with procedures, which are called in statements
 
-* Function calls can appear in expressions, so function calls must be free from side-effects
+* Function calls can appear in expressions, so function calls **must** be free from side-effects
 
-  - Nice benefit is that functions have a simpler logical interpretation
+  - Nice benefit is that functions have a **simpler logical interpretation**
 
 * What is a side-effect?
 
@@ -197,10 +196,9 @@ Functions May Not Have Side-Effects
 What Is a Side-Effect?
 ------------------------
 
-* An expression is side-effect free if its evaluation does not update any object
+* An expression is **side-effect free** if its evaluation **does not update** any object
 
-  - `out` and `in out` parameters of a call
-
+  - :ada:`out` and :ada:`in out` parameters of a call
   - global variables written by a call
 
 .. code:: Ada
@@ -242,7 +240,7 @@ Why not Side Effects - Writing Globals
 
    Gear_Down (Global, F);
 
-* Causes Order-Dependent Code (ODC)
+* Causes Order-Dependent Code (:dfn:`ODC`)
 
    - If left parameter evaluated first, X=0, Y=1
    - If right parameter evaluated first, X=1, Y=1
@@ -292,12 +290,12 @@ Why not Side Effects - `in out` Formals (2/2)
 
 * Causes Order-Dependent Code
 
-  - If `Values (Index)` evaluated first, result = "22345"
-  - If `F (Index)` evaluated first, result = "12345"
+  - If :ada:`Values (Index)` evaluated first, result = "22345"
+  - If :ada:`F (Index)` evaluated first, result = "12345"
 
 .. container:: speakernote
 
-For the array assignment (the first statement), the language doesn't say whether the LHS is evaluated first, or the RHS.
+    For the array assignment (the first statement), the language doesn't say whether the LHS is evaluated first, or the RHS.
 
 -------------------------
 Parameter Name Aliasing
@@ -334,7 +332,7 @@ Parameter Aliasing with Global Variable
 
 .. container:: speakernote
 
-   Rejected in SPARK if Print is not inlined so we would need to either add a precondition or use the --no-inlining GNATprove switch.
+   Rejected in SPARK if Print is not inlined so we would need to either add a precondition or use the --no-inlining :toolname:`GNATprove` switch.
    This is a bounded error in Ada 2012. It might raise Program Error, but it might just run (i.e., not be detected) and do whatever it will do.
    What it will do depends on how Formal is passed, and that is up to the compiler since Character is a by-copy type.  If passed by copy, the assignment to Actual does not affect the copy in Formal.
    See RM 6.4.1 paragraphs 6/17-19
@@ -391,7 +389,6 @@ Parameter Aliasing Prevention In SPARK
 * Input and output parameters must not be aliased, if there is possible interference
 * Output parameters must never be aliased with global variables referenced by the subprogram
 * Input parameters must not be aliased with global variables written by the subprogram, unless they are always passed by copy (reading is OK)
-
 * Functions cannot have outputs (parameters or global variables) hence cannot introduce illegal aliasing
 
 ----------------------------
@@ -399,24 +396,22 @@ Data Initialization Policy
 ----------------------------
 
 * Modes on formal parameters and data dependency contracts have a stricter meaning than in Ada
-* Mode `in` (and global mode `Input`): the object should be completely initialized before the call
-* Mode `out` (and global mode `Output`): the object should be completely initialized before returning
-* Mode `in out` (and global mode `In_Out`): the object should be completely initialized before calling the subprogram
+* Mode :ada:`in` (and global mode `Input`): the object should be completely initialized before the call
+* Mode :ada:`out` (and global mode `Output`): the object should be completely initialized before returning
+* Mode :ada:`in out` (and global mode `In_Out`): the object should be completely initialized before calling the subprogram
 
 -----------------------------------------
 Data Initialization Policy Consequences
 -----------------------------------------
 
 * All inputs must be completely initialized on entry
-
 * All outputs must be completely initialized on exit
-
 * All objects must be completely initialized when read
 
    - Except for record objects, provided those components that are read are initialized
    - Above rule exception doesn't apply to array objects
 
-* A parameter or global variable partially written in a subprogram should be mode `in out`, not mode `out`
+* A parameter or global variable partially written in a subprogram should be mode :ada:`in out`, not mode :ada:`out`
 * :toolname:`GNATprove` will complain if policy is violated
 
 -------------------------------------------
@@ -424,7 +419,6 @@ No Initialization Across Library Packages
 -------------------------------------------
 
 * In SPARK, package elaboration cannot initialize variables declared in other library packages
-
 * In combination with other rules, prevents elaboration order issues
 
 .. code:: Ada
@@ -505,7 +499,7 @@ Mixing SPARK and Ada
 Identifying SPARK Code
 ------------------------
 
-* Aspect and `pragma SPARK_Mode` specify whether code is intended to be in SPARK
+* Aspect and :ada:`pragma SPARK_Mode` specify whether code is intended to be in SPARK
 
    - Argument values are `On` and `Off`
 
@@ -625,7 +619,6 @@ Two General Principles for Mixing
 * The word **reference** is key:
 
    - The spec is what is referenced (i.e., the declaration) so the completion needs not be in SPARK
-
    - A non-SPARK package can be with'ed by SPARK code as long as the referenced parts comply with the SPARK subset
 
 ---------------------------------
@@ -782,7 +775,7 @@ What If the Mode Is Not Explicitly Set?
 
    - Their implementations are not analyzed by :toolname:`GNATprove`
 
-* Allowed for Ada packages named in `with` clauses
+* Allowed for Ada packages named in :ada:`with` clauses
 
    - Language-defined packages
    - Application packages to be reused without analysis
@@ -909,7 +902,6 @@ SPARK Key Tools
 * GNAT compiler
 
    - checks conformance of source with Ada and SPARK
-
    - compiles source into executable
 
 * :toolname:`GNATprove`
@@ -949,7 +941,7 @@ SPARK Key Tools
 
 .. container:: speakernote
 
-   CodePeer has been removed in release 23
+   :toolname:`CodePeer` has been removed in release 23
 
 ----------------------------------------
 :toolname:`GNATprove` Output for Users
@@ -964,7 +956,7 @@ Analysis Summary File "gnatprove.out"
 * Located in :filename:`gnatprove/` under project object dir
 * An overview of results for all checks in project
 * Especially useful when results must be documented
-* Details in the UG *"How to View GNATprove Output"*
+* Details in the UG *"How to View :toolname:`GNATprove` Output"*
 
 |
 
@@ -1003,7 +995,7 @@ Analysis Summary File "gnatprove.out"
 
    - Indicate suspicious situations, e.g., useless assignments
    - Prefixed with **warning:**
-   - Can be suppressed with `pragma Warnings`
+   - Can be suppressed with :ada:`pragma Warnings`
 
       .. code:: console
 
@@ -1015,7 +1007,7 @@ Analysis Summary File "gnatprove.out"
    - E.g., possible failing run-time checks or unproved contracts
    - Prefixed with **low** or **medium** or **high**
    - Cannot be suppressed like warning messages
-   - Can be individually justified with `pragma Annotate`
+   - Can be individually justified with :ada:`pragma Annotate`
 
       .. code:: console
 
@@ -1076,7 +1068,6 @@ What Is Verified In "prove" Mode
 ----------------------------------
 
 * SPARK subset conformance
-
 * Success proves absence of run-time errors
 
    - From Ada language-defined run-time checks
@@ -1087,7 +1078,6 @@ What Is Verified In "prove" Mode
 * With preconditions and postconditions, success proves those contracts always hold
 
    - Unit functionality, as expressed in postconditions
-
    - Any arbitrary boolean properties you specified
 
 * If you get check messages, change the code...
@@ -1120,7 +1110,6 @@ Which Mode To Use?
    - E.g., invalid data initialization may invalidate proof
 
 * Thus make sure you pass flow analysis (using "flow" mode) before moving on to "proof" mode
-
 * Consider that mode "all" does all the necessary analyses and does them in the necessary order
 
 ------------------------------------------

--- a/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
@@ -2,7 +2,29 @@
 Data Flow Analysis
 ********************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
 .. |checkmark| replace:: :math:`\checkmark`
 
 ==============

--- a/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
@@ -35,9 +35,9 @@ Introduction
 Overview
 ----------
 
-* What is flow analysis?
-* Which errors does it detect?
-* How does flow analysis work?
+* **What** is flow analysis?
+* Which **errors** does it detect?
+* How does flow analysis **work**?
 * Flow analysis of composite objects
 * Global data
 * Flow analysis using :toolname:`GNATprove`
@@ -46,18 +46,18 @@ Overview
 What is Flow Analysis
 =======================
 
-------------------------
-What is Flow Analysis?
-------------------------
+----------------------------
+**What** is Flow Analysis?
+----------------------------
 
 * Static analysis performed by :toolname:`GNATprove`
-* Models the variables used by a subprogram
+* Models the **variables** used by a subprogram
 
    - Global variables
    - Local variables
    - Formal parameters
 
-* Models how information flows through the statements in the subprogram
+* Models how **information flows** through the statements in the subprogram
 
    - From initial values of variables
    - To final values of variables
@@ -73,19 +73,19 @@ What is Flow Analysis?
 Detecting Errors (or "Issues")
 --------------------------------
 
-* What Classes of Errors Does It Detect?
+* Which **Classes of Errors** Does It Detect?
 
-   - Use of uninitialized variables
-   - Ineffective statements
+   - Use of **uninitialized** variables
+   - **Ineffective** statements
 
       + Statements which update variables
-      + But which have no effect on the final value of any variable
+      + But which have **no effect** on the final value of any variable
 
-   - Detecting unused variables
+   - Detecting **unused** variables
 
-      + Not considered an error in SPARK
-      + But probably is a coding error
-      + Generates warnings
+      + **Not** considered an error in SPARK
+      + But **probably** is a coding error
+      + Generates **warnings**
 
 * More classes of errors can be detected if contracts are added, more about that later...
 
@@ -148,16 +148,16 @@ Ineffective Statements
 
  .. container:: column
 
-    * Have no effect on any output variable
+    * Have **no effect** on any output variable
 
        - Therefore no effect on behavior of code
 
-    * Are different from dead code
+    * Are **different** from dead code
 
        - They are executed
-       - May modify some variables, but not outputs
+       - **May** modify some variables, but not outputs
 
-    * Usually indicate a coding error
+    * Usually indicate a **coding error**
 
 ----------------------------
 Detecting Unused Variables
@@ -198,13 +198,13 @@ Incorrect Parameter Mode
 
     -
 
-    - in
+    - :ada:`in`
 
   * - |checkmark|
 
     - |checkmark|
     - |checkmark|
-    - in out
+    - :ada:`in out`
 
   * -
 
@@ -212,14 +212,14 @@ Incorrect Parameter Mode
 
     -
 
-    - in out
+    - :ada:`in out`
 
   * -
 
     -
 
     - |checkmark|
-    - out
+    - :ada:`out`
 
 * Detection of incorrect mode of parameters (:ada:`in`, :ada:`out`, or :ada:`in out`)
 
@@ -241,26 +241,26 @@ Incorrect Parameter Mode
    Finally, flow analysis will also warn when an in out parameter is not updated or when its initial value is not used in the subprogram, as it may be the sign of an error. An example is shown on this slide in the subprogram called Swap.
    Note that, in SPARK, a parameter which is not read but not updated on every path should be declared as in out as its final value may depend on its initial value.
 
-==============================
-Why Do We Need Flow Analysis
-==============================
+==================================
+**Why** Do We Need Flow Analysis
+==================================
 
 ---------------------------------
 Flow Analysis - Why Do We Care?
 ---------------------------------
 
-* Ensure there is no dead code
-* Improper initialization errors are listed as one of the most dangerous programming errors
+* Ensure there is **no dead code**
+* Improper initialization errors are listed as one of the **most dangerous** programming errors
 
-   - The SPARK flow analysis identifies all variables that have not been initialized prior to them being read.
-   - If the SPARK flow analysis finds no uninitialized variables, then there really are none!
+   - The SPARK flow analysis identifies **all** variables that have not been initialized prior to them being read.
+   - If the SPARK flow analysis finds no uninitialized variables, then there **really** are none!
 
 * Identifying ineffective statements
-* Well-defined basis for deeper analysis (proof)
+* Well-defined basis for **deeper** analysis (proof)
 * Security properties
 
    - Advanced flow analysis with contracts, more about this later...
-   - Not sound in the presence of some of these errors
+   - **Not sound** in the presence of some of these errors
 
 .. container:: speakernote
 
@@ -270,10 +270,10 @@ Flow Analysis - Why Do We Care?
 Modularity
 ------------
 
-* Flow analysis, and in particular detection of uninitialized variables, is done modularly on a per subprogram basis
+* Flow analysis, and in particular detection of uninitialized variables, is done modularly on a **per subprogram** basis
 
-   - Global and parameter inputs should be initialized prior to any subprogram call
-   - Global and parameter outputs should be initialized prior to subprogram return
+   - Global and parameter **inputs** should be initialized prior to any subprogram **call**
+   - Global and parameter **outputs** should be initialized prior to subprogram **return**
 
 .. code:: Ada
 
@@ -307,11 +307,11 @@ Modularity
 Value Dependency
 ------------------
 
-* Flow analysis is not value dependent
+* Flow analysis is **not value dependent**
 
    - It only reasons in terms of control flow
 
-* Flow analysis does not know that `R` is initialized:
+* Flow analysis **does not know** that :ada:`R` is initialized in:
 
   .. code:: Ada
 
@@ -325,7 +325,7 @@ Value Dependency
        end if;
      end Absolute_Value;
 
-* Flow analysis knows that `R` is initialized:
+* Flow analysis **knows** that :ada:`R` is initialized in:
 
   .. code:: Ada
 
@@ -350,12 +350,12 @@ Value Dependency
 Flow Analysis of Composite Objects
 ------------------------------------
 
-* Arrays
+* :ada:`array`
 
    - Flow analysis treats array objects as single, entire objects
    - Changing one element of an array object preserves the value of the other elements
 
-* Records
+* :ada:`record`
 
    - Updating and reading of fields of records is analyzed in terms of those fields
    - Updates and reads not treated as operations on records in their entirety
@@ -383,24 +383,24 @@ Arrays and Flow Analysis
 Array Elements and Flow Analysis
 ----------------------------------
 
-* Let's assume the initial value of `A` is (x, y), and we execute the assignment statement:
+* Let's assume the initial value of :ada:`A` is :ada:`(x, y)`, and we execute the assignment statement:
 
    .. code:: Ada
 
       A (I) := True;
 
-* The final value of `A` might be (True, y) or (x, True) depending on the value of `I`
+* The final value of :ada:`A` might be :ada:`(True, y)` or :ada:`(x, True)` depending on the value of :ada:`I`
 * Note that at least one element of the initial value is preserved in both cases
-* So the final value of `A` must depend on:
+* So the final value of :ada:`A` must depend on:
 
-   - Initial value of `A` (because one element of `A` is preserved)
-   - Value of `I` (because `I` specifies which element of `A` is updated)
+   - Initial value of :ada:`A` (because one element of :ada:`A` is preserved)
+   - Value of :ada:`I` (because :ada:`I` specifies which element of :ada:`A` is updated)
 
 --------------------------
 Array Element Assignment
 --------------------------
 
-* Let's assume the initial value of `A` is (x, y), and we execute the assignment statements:
+* Let's assume the initial value of :ada:`A` is :ada:`(x, y)`, and we execute the assignment statements:
 
    .. code:: Ada
 
@@ -410,18 +410,18 @@ Array Element Assignment
 * Three possible outcomes:
 
 |
-   :(True, y): if I = J = 1
-   :(x, True): if I = J = 2
-   :(True, True): if I /= J
+   :``(True, y)``: :ada:`if I = J = 1`
+   :``(x, True)``: :ada:`if I = J = 2`
+   :``(True, True)``: :ada:`if I /= J`
 
-* Flow analysis doesn't know the values of `I` and `J` so conservatively assumes that `A` depends on `A`, `I` and `J`
+* Flow analysis doesn't know the values of :ada:`I` and :ada:`J` so conservatively assumes that :ada:`A` depends on :ada:`A`, :ada:`I` and :ada:`J`
 
 ------------------
 Array Assignment
 ------------------
 
-* In general, there is no way for the flow analyzer to determine whether a sequence of assignments to an array has updated all the elements of the array or a subset of them
-* So initializing an array with a sequence of statements will result in a flow error
+* In general, there is **no way** for the flow analyzer to determine whether a sequence of assignments to an array has updated **all** the elements of the array **or a subset** of them
+* So initializing an array with a sequence of statements will result in a **flow error**
 
    .. code:: Ada
 
@@ -431,13 +431,13 @@ Array Assignment
          A (2) := True;
       end Init_Array;
 
-* Don't "fix" this by changing the mode of `A` to :ada:`in out`
+* Don't "fix" this by changing the mode of :ada:`A` to :ada:`in out`
 
 ----------------------
 Array Initialization
 ----------------------
 
-* If possible, use an aggregate to initialize the array
+* If possible, use an **aggregate** to initialize the array
 
    .. code:: Ada
 
@@ -448,7 +448,7 @@ Array Initialization
 
    - (:ada:`others` could be used in this particular instance)
 
-* Flow analysis knows that the array must be fully defined by the aggregate, so no errors are reported
+* Flow analysis **knows** that the array must be fully defined by the aggregate, so no errors are reported
 
 =============
 Global Data
@@ -458,9 +458,9 @@ Global Data
 Global Variables
 ------------------
 
-* Impact code organization
-* Are part of the signature (from the verification perspective)
-* May seem innocent at first, but often cause unexpected effects as programs grow.
+* Impact **code organization**
+* Are part of the **signature** (from the verification perspective)
+* May seem innocent at first, but often cause **unexpected effects** as programs grow.
 
    - (Not saying that you should not have them, or that they are evil.)
 
@@ -468,64 +468,50 @@ Global Variables
 What Is a Global Variable?
 ----------------------------
 
-.. container:: columns
+* Any variable that is an input or output of a subprogram (that is not a parameter) is a global
 
- .. container:: column
 
-    * Any variable that is an input or output of a subprogram (that is not a parameter) is a global
+.. code:: Ada
 
- .. container:: column
+   procedure Read_Global (Value : out Integer) is
+   begin
+      Value := Global;
+   end Read_Global;
 
-    .. code:: Ada
+   procedure Global_Above_Zero (Value : out Boolean) is
+   begin
+      Value := (X > 0);
+   end Global_Above_Zero;
 
-       procedure Read_Global
-          (Value : out Integer)
-       is
-       begin
-          Value := Global;
-       end Read_Global;
-       procedure Global_Above_Zero
-          (Value : out Boolean)
-       is
-       begin
-          Value := (X > 0);
-       end Global_Above_Zero;
+-----------------------------
+:ada:`Global` Contract
+-----------------------------
 
------------------
-Global Contract
------------------
+* **Announces** use of global variables
+* Optional mode can be :ada:`Input` (default), :ada:`Output`, :ada:`In_Out` or :ada:`Proof_In`
+* :ada:`Proof_In` specifies globals that are **only** referenced within **assertions** in the subprogram
 
-.. container:: columns
+.. code:: Ada
 
- .. container:: column
+   procedure P
+      with Global =>
+      (Input    => (A, B, C),
+       Output   => (L, M, N),
+       In_Out   => (X, Y, Z),
+       Proof_In => (I, J, K));
 
-    * Announces use of global variables
-    * Optional mode can be `Input` (default), `Output`, `In_Out` or `Proof_In`
-    * `Proof_In` specifies globals that are only referenced within assertions in the subprogram
-
- .. container:: column
-
-    .. code:: Ada
-
-       procedure P
-          with Global =>
-          (Input    => (A, B, C),
-           Output   => (L, M, N),
-           In_Out   => (X, Y, Z),
-           Proof_In => (I, J, K));
-
------------------
-Global Contract
------------------
+------------------------
+:ada:`Global` Contract
+------------------------
 
 * Optional
-* So existing code can be analyzed without adding globals
+* So existing code can be analyzed **without adding globals**
 
-   - Tools will then compute them by default
+   - Tools will then compute them **by default**
 
-* But if present, global contract must be complete and correct
+* But **if present**, global contract must be **complete and correct**
 * Can be omitted if there are no globals
-* :ada:`null` gives a positive indication that there are no globals
+* :ada:`null` gives a positive indication that there are **no globals**
 * The option :command:`--no-global-generation` prohibits global generation, instead assumes :ada:`null`
 
    - **NOTE** Omitted global declaration means global :ada:`null` with this option
@@ -538,9 +524,9 @@ Global Contract
 Functions Without Side-Effects
 --------------------------------
 
-* Recall: An expression is side-effect free if its evaluation does not update any object
-* Objects updated by subprogram call are any parameters of mode :ada:`out` (or :ada:`in out`) and any globals of mode `Output` (or `In_Out`)
-* So function is side-effect free if all parameters and globals (if any) are of mode :ada:`in` / `Input` / `Proof_In` only
+* Recall: An expression is side-effect free if its **evaluation does not update** any object
+* Objects updated by subprogram call are any parameters of mode :ada:`out` (or :ada:`in out`) and any globals of mode :ada:`Output` (or :ada:`In_Out`)
+* So function is side-effect free if all parameters and globals (if any) are of mode :ada:`in` / :ada:`Input` / :ada:`Proof_In` only
 
 .. code:: Ada
 
@@ -590,14 +576,14 @@ Aliasing Revisited - Output of Global
       procedure Update_Y (X : in Some_Type)
          with Global => (Output => Y);
 
-* Aliasing may be detected at the point where a call is made
+* **Aliasing** may be detected at the point where a **call is made**
 
-   .. code:: Ada
+.. code:: Ada
 
-      Y, Z : Some_Type;
-      ...
-      Update_Y (Z); -- OK
-      Update_Y (Y); -- Illegal unless Some_Type is pass-by-copy
+  Y, Z : Some_Type;
+  ...
+  Update_Y (Z); -- OK
+  Update_Y (Y); -- Illegal unless Some_Type is pass-by-copy
 
 .. container:: speakernote
 
@@ -608,7 +594,7 @@ Aliasing Revisited - Output of Global
 Aliasing Revisited - Input of Global
 ---------------------------------------
 
-* As previous example except this time the formal parameter is the export
+* As previous example except this time the formal parameter **is** the export
 
    .. code:: Ada
 
@@ -659,7 +645,7 @@ Summary
 Summary
 ----------
 
-- Data Flow Analysis helps in achieving Bronze Level verification
+- Data Flow Analysis helps in achieving **Bronze Level verification**
 
    + No reading of uninitialized data
    + No interference between parameters and global data

--- a/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/040_data_flow_analysis.rst
@@ -189,9 +189,7 @@ Incorrect Parameter Mode
   * - Initial Value
 
     - Some Path Updated
-
     - Every Path Updated
-
     - Parameter Mode
 
   * - |checkmark|
@@ -205,9 +203,7 @@ Incorrect Parameter Mode
   * - |checkmark|
 
     - |checkmark|
-
     - |checkmark|
-
     - in out
 
   * -
@@ -223,10 +219,9 @@ Incorrect Parameter Mode
     -
 
     - |checkmark|
-
     - out
 
-* Detection of incorrect mode of parameters (`in`, `out`, or `in out`)
+* Detection of incorrect mode of parameters (:ada:`in`, :ada:`out`, or :ada:`in out`)
 
 .. code:: Ada
 
@@ -255,11 +250,9 @@ Flow Analysis - Why Do We Care?
 ---------------------------------
 
 * Ensure there is no dead code
-
 * Improper initialization errors are listed as one of the most dangerous programming errors
 
    - The SPARK flow analysis identifies all variables that have not been initialized prior to them being read.
-
    - If the SPARK flow analysis finds no uninitialized variables, then there really are none!
 
 * Identifying ineffective statements
@@ -365,7 +358,6 @@ Flow Analysis of Composite Objects
 * Records
 
    - Updating and reading of fields of records is analyzed in terms of those fields
-
    - Updates and reads not treated as operations on records in their entirety
 
 =========================
@@ -439,7 +431,7 @@ Array Assignment
          A (2) := True;
       end Init_Array;
 
-* Don't "fix" this by changing the mode of `A` to `in out`
+* Don't "fix" this by changing the mode of `A` to :ada:`in out`
 
 ----------------------
 Array Initialization
@@ -454,7 +446,7 @@ Array Initialization
          A := (1 .. 2 => True);
       end Init_Array;
 
-   - (`others` could be used in this particular instance)
+   - (:ada:`others` could be used in this particular instance)
 
 * Flow analysis knows that the array must be fully defined by the aggregate, so no errors are reported
 
@@ -467,7 +459,6 @@ Global Variables
 ------------------
 
 * Impact code organization
-
 * Are part of the signature (from the verification perspective)
 * May seem innocent at first, but often cause unexpected effects as programs grow.
 
@@ -528,17 +519,16 @@ Global Contract
 -----------------
 
 * Optional
-
 * So existing code can be analyzed without adding globals
 
    - Tools will then compute them by default
 
 * But if present, global contract must be complete and correct
 * Can be omitted if there are no globals
-* `null` gives a positive indication that there are no globals
-* The option :command:`--no-global-generation` prohibits global generation, instead assumes `null`
+* :ada:`null` gives a positive indication that there are no globals
+* The option :command:`--no-global-generation` prohibits global generation, instead assumes :ada:`null`
 
-   - **NOTE** Omitted global declaration means global `null` with this option
+   - **NOTE** Omitted global declaration means global :ada:`null` with this option
 
 .. container:: speakernote
 
@@ -549,8 +539,8 @@ Functions Without Side-Effects
 --------------------------------
 
 * Recall: An expression is side-effect free if its evaluation does not update any object
-* Objects updated by subprogram call are any parameters of mode `out` (or `in out`) and any globals of mode `Output` (or `In_Out`)
-* So function is side-effect free if all parameters and globals (if any) are of mode `in` / `Input` / `Proof_In` only
+* Objects updated by subprogram call are any parameters of mode :ada:`out` (or :ada:`in out`) and any globals of mode `Output` (or `In_Out`)
+* So function is side-effect free if all parameters and globals (if any) are of mode :ada:`in` / `Input` / `Proof_In` only
 
 .. code:: Ada
 

--- a/courses/spark_for_ada_programmers/050_quantified_expressions.rst
+++ b/courses/spark_for_ada_programmers/050_quantified_expressions.rst
@@ -1,9 +1,31 @@
-
 ************************
 Quantified Expressions
 ************************
 .. |forall| replace:: :math:`\forall`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/060_contracts.rst
+++ b/courses/spark_for_ada_programmers/060_contracts.rst
@@ -1,8 +1,31 @@
-
 ***********
 Contracts
 ***********
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/070_type_contracts.rst
+++ b/courses/spark_for_ada_programmers/070_type_contracts.rst
@@ -1,8 +1,31 @@
-
 ****************
 Type Contracts
 ****************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
+++ b/courses/spark_for_ada_programmers/080_proving_programs_correct.rst
@@ -1,7 +1,31 @@
-
 **************************
 Proving Programs Correct
 **************************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
+++ b/courses/spark_for_ada_programmers/090_proving_absence_of_run_time_errors.rst
@@ -1,8 +1,31 @@
-
 ************************************
 Proving Absence of Run Time Errors
 ************************************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
+++ b/courses/spark_for_ada_programmers/100_the_proof_cycle.rst
@@ -1,7 +1,31 @@
-
 *****************
 The Proof Cycle
 *****************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
+++ b/courses/spark_for_ada_programmers/110_advanced_proof_techniques.rst
@@ -1,8 +1,31 @@
-
 ***************************
 Advanced Proof Techniques
 ***************************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/120_depends_contract_and_information_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/120_depends_contract_and_information_flow_analysis.rst
@@ -1,9 +1,30 @@
-
 ************************************************
 Depends Contract and Information Flow Analysis
 ************************************************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
 .. |checkmark| replace:: :math:`\checkmark`
 
 ==============

--- a/courses/spark_for_ada_programmers/130_state_abstraction.rst
+++ b/courses/spark_for_ada_programmers/130_state_abstraction.rst
@@ -1,8 +1,31 @@
-
 *******************
 State Abstraction
 *******************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/140_interfacing_to_other_languages.rst
+++ b/courses/spark_for_ada_programmers/140_interfacing_to_other_languages.rst
@@ -1,7 +1,31 @@
-
 ********************************
 Interfacing to Other Languages
 ********************************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/150_crossing_the_spark_boundary.rst
+++ b/courses/spark_for_ada_programmers/150_crossing_the_spark_boundary.rst
@@ -1,8 +1,31 @@
-
 *****************************
 Crossing the SPARK boundary
 *****************************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/160_interfacing.rst
+++ b/courses/spark_for_ada_programmers/160_interfacing.rst
@@ -1,8 +1,31 @@
-
 *************
 Interfacing
 *************
 .. |rightarrow| replace:: :math:`\rightarrow`
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/170_designing_for_spark.rst
+++ b/courses/spark_for_ada_programmers/170_designing_for_spark.rst
@@ -1,7 +1,31 @@
-
 *********************
 Designing for SPARK
 *********************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ==============
 Introduction

--- a/courses/spark_for_ada_programmers/180_adoption_guidance.rst
+++ b/courses/spark_for_ada_programmers/180_adoption_guidance.rst
@@ -1,7 +1,31 @@
-
 *******************
 Adoption Guidance
 *******************
+
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
+.. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 -------------------------
 SPARK Adoption Guidance

--- a/courses/spark_for_ada_programmers/990_spark_example_project.rst
+++ b/courses/spark_for_ada_programmers/990_spark_example_project.rst
@@ -2,7 +2,30 @@
 SPARK Example Project
 ***********************
 
+..
+    Coding language
+
+.. role:: ada(code)
+    :language: Ada
+
+.. role:: C(code)
+    :language: C
+
+.. role:: cpp(code)
+    :language: C++
+
+..
+    Math symbols
+
 .. |rightarrow| replace:: :math:`\rightarrow`
+.. |forall| replace:: :math:`\forall`
+.. |exists| replace:: :math:`\exists`
+.. |equivalent| replace:: :math:`\iff`
+
+..
+    Miscellaneous symbols
+
+.. |checkmark| replace:: :math:`\checkmark`
 
 ------------
 Background


### PR DESCRIPTION
- add spark to files with preludes
- fix prelude for SPARK files
- 020 spark: further bold
- 020: warning about SPARK not being a Ada subset
- 020: NASA plume Mach example
- spark 020: dfn and bold
- spark 020: bold
- spark 030: bold
- spark 030: linter
- spark 020: nit unchecked Ada -> Ada.Unchecked_Conversion
- spark 030: bold
- spark 020: entirely remove Unchecked_Conversion ref
- spark 030: bold, and :ada:``
- spark 030: emphases
- spark 040: linter
- spark 040: emphase, more :ada:
