### PR TITLE
Training 2023/01/30 PAT: Fixups

### DIFF
--- a/contrib/quiz.py
+++ b/contrib/quiz.py
@@ -266,7 +266,6 @@ if __name__ == "__main__":
     quiz = Quiz(args.input_file)
 
     pout("..")
-    pout()
     pout(
         "    This file is auto-generated from the quiz template, it should not be modified"
     )

--- a/contrib/quiz_update.py
+++ b/contrib/quiz_update.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     if (args.main_directory / args.quiz_file_name).is_file():
         quizzes = [args.main_directory / args.quiz_file_name]
     else:
-        quizzes = list(sorted(args.main_directory.glob(f"*/{args.quiz_file_name}")))
+        quizzes = list(sorted(args.main_directory.glob(f"**/{args.quiz_file_name}")))
     assert len(quizzes) != 0
 
     for f in quizzes:

--- a/courses/advanced_exception_analysis/010_advanced_exception_analysis.rst
+++ b/courses/advanced_exception_analysis/010_advanced_exception_analysis.rst
@@ -21,6 +21,10 @@ Advanced Exception Analysis
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/codepeer/010_codepeer.rst
+++ b/courses/codepeer/010_codepeer.rst
@@ -21,6 +21,10 @@
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/codepeer/labs/cruise/instructions.rst
+++ b/courses/codepeer/labs/cruise/instructions.rst
@@ -126,11 +126,11 @@ Eg. "Most optional warnings" `-gnatwa` is first, then "Failing assertions" `-gna
 
 Each warning can be either unselected, or a bar or a checkmark
 
-The bar indicates that the warning is implicitely checked by CodePeer.
+The bar indicates that the warning is implicitly checked by CodePeer.
 
 .. image:: codepeer/cruise_analysis_warnings_bar.png
 
-The checkmark indicates that the warning is explicitely checked by CodePeer.
+The checkmark indicates that the warning is explicitly checked by CodePeer.
 
 .. image:: codepeer/cruise_analysis_warnings_check.png
 

--- a/courses/fundamentals_of_ada/010_overview.rst
+++ b/courses/fundamentals_of_ada/010_overview.rst
@@ -21,6 +21,10 @@ Overview
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/020_declarations.rst
+++ b/courses/fundamentals_of_ada/020_declarations.rst
@@ -21,6 +21,10 @@ Declarations
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -840,7 +840,7 @@ Floating Point Type Attributes
    - :ada:`Real'Rounding (X)`
 
       + Integral value nearest to :ada:`X`
-      + *Note* :ada:`Float'Rounding (0.5) = 1`
+      + *Note* :ada:`Float'Rounding (0.5) = 1` and :ada:`Float'Rounding (-0.5) = -1`
 
 * Model-oriented attributes
 
@@ -855,7 +855,7 @@ Numeric Types Conversion
 
     - Holding a numeric value
 
-* Special rule: they can always be converted inbetween them
+* Special rule: can always convert between numeric types
 
     - Explicitely
     - :ada:`Real` |rightarrow| :ada:`Integer` causes **rounding**

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -867,7 +867,7 @@ Numeric Types Conversion
       F : Float := 1.5;
    begin
       N := Integer (F); -- N = 2
-      F := Integer (N); -- F = 2.0
+      F := Float (N); -- F = 2.0
 
 ------
 Quiz

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -857,7 +857,7 @@ Numeric Types Conversion
 
 * Special rule: can always convert between numeric types
 
-    - Explicitely
+    - Explicitly
     - :ada:`Real` |rightarrow| :ada:`Integer` causes **rounding**
 
 .. code:: Ada
@@ -920,8 +920,8 @@ Miscellaneous
 * Functional syntax
 
    - Function named :ada:`Target_Type`
-   - Implicitely defined
-   - **Must** be explicitely called
+   - Implicitly defined
+   - **Must** be explicitly called
 
 .. code:: Ada
 

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -843,6 +843,28 @@ Floating Point Type Attributes
    - Advanced machine representation of the floating-point type
    - Mantissa, strict mode
 
+---------------------------
+Numeric Types Conversion
+---------------------------
+
+* Ada's integer and real are :dfn:`numeric`
+
+    - Holding a numeric value
+
+* Special rule: they can always be converted inbetween them
+
+    - Explicitely
+    - :ada:`Real` :rightarrow: :ada:`Integer` causes **rounding**
+
+.. code:: Ada
+
+   declare
+      N : Integer := 0;
+      F : Float := 1.5;
+   begin
+      N := Integer (F); -- N = 2
+      F := Integer (N); -- F = 2.0
+
 ------
 Quiz
 ------

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -858,7 +858,7 @@ Numeric Types Conversion
 * Special rule: they can always be converted inbetween them
 
     - Explicitely
-    - :ada:`Real` :rightarrow: :ada:`Integer` causes **rounding**
+    - :ada:`Real` |rightarrow| :ada:`Integer` causes **rounding**
 
 .. code:: Ada
 

--- a/courses/fundamentals_of_ada/030_basic_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types.rst
@@ -21,6 +21,10 @@ Basic Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/040_statements.rst
+++ b/courses/fundamentals_of_ada/040_statements.rst
@@ -21,6 +21,10 @@ Statements
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -21,6 +21,10 @@ Array Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/060_record_types.rst
+++ b/courses/fundamentals_of_ada/060_record_types.rst
@@ -21,6 +21,10 @@ Record Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/065_type_derivation.rst
+++ b/courses/fundamentals_of_ada/065_type_derivation.rst
@@ -21,6 +21,10 @@ Type Derivation
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/070_subprograms.rst
+++ b/courses/fundamentals_of_ada/070_subprograms.rst
@@ -381,14 +381,20 @@ Actual Parameters Respect Constraints
      Foo (Q); -- runtime error if Q <= 0
      Foo (P);
 
------------------
-Parameter Modes
------------------
+---------------------------
+Parameter and Return Mode
+---------------------------
 
 * Mode :ada:`in`
 
    - Actual parameter is :ada:`constant`
-   - Can have default, used when **no value** is provided
+   - Can have **default**, used when **no value** is provided
+
+    .. code:: Ada
+
+       procedure P (N : in Integer := 1; M : in Positive);
+       [...]
+       P (M => 2);
 
 * Mode :ada:`out`
 

--- a/courses/fundamentals_of_ada/070_subprograms.rst
+++ b/courses/fundamentals_of_ada/070_subprograms.rst
@@ -385,9 +385,9 @@ Actual Parameters Respect Constraints
      Foo (Q); -- runtime error if Q <= 0
      Foo (P);
 
----------------------------
-Parameter and Return Mode
----------------------------
+----------------------------
+Parameter Modes and Return
+----------------------------
 
 * Mode :ada:`in`
 

--- a/courses/fundamentals_of_ada/070_subprograms.rst
+++ b/courses/fundamentals_of_ada/070_subprograms.rst
@@ -21,6 +21,10 @@ Subprograms
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/080_expressions.rst
+++ b/courses/fundamentals_of_ada/080_expressions.rst
@@ -21,6 +21,10 @@ Expressions
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/090_overloading.rst
+++ b/courses/fundamentals_of_ada/090_overloading.rst
@@ -21,6 +21,10 @@ Overloading
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/095_library_units.rst
+++ b/courses/fundamentals_of_ada/095_library_units.rst
@@ -21,6 +21,10 @@ Library Units
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/100_packages.rst
+++ b/courses/fundamentals_of_ada/100_packages.rst
@@ -21,6 +21,10 @@ Packages
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/100_packages.rst
+++ b/courses/fundamentals_of_ada/100_packages.rst
@@ -339,6 +339,8 @@ Required Body Example
 Quiz
 ------
 
+.. include:: quiz/package_subprogram_completion/quiz.rst
+
 .. code:: Ada
 
    package P is

--- a/courses/fundamentals_of_ada/110_private_types.rst
+++ b/courses/fundamentals_of_ada/110_private_types.rst
@@ -21,6 +21,10 @@ Private Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/120_limited_types.rst
+++ b/courses/fundamentals_of_ada/120_limited_types.rst
@@ -21,6 +21,10 @@ Limited Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/130_program_structure.rst
+++ b/courses/fundamentals_of_ada/130_program_structure.rst
@@ -21,6 +21,10 @@ Program Structure
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/135_visibility.rst
+++ b/courses/fundamentals_of_ada/135_visibility.rst
@@ -21,6 +21,10 @@ Visibility
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -458,7 +458,7 @@ Introduction to Accessibility Checks (1/2)
                -- Nested subprogram, enclosing + 1, here 2
                O2 : aliased Integer;
 
-* Objects can be access by access **types** that are at **same depth or deeper**
+* Objects can be referenced by access **types** that are at **same depth or deeper**
 
     - An **access scope** must be |le| the object scope
 

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -458,7 +458,10 @@ Introduction to Accessibility Checks (1/2)
                -- Nested subprogram, enclosing + 1, here 2
                O2 : aliased Integer;
 
-* Access **types** can only access objects that are at **same or lower depth**
+* Objects can be access by access **types** that are at **same depth or deeper**
+
+    - An **access scope** must be |le| the object scope
+
 * :ada:`type Acc1` (depth 1) can access :ada:`O0` (depth 0) but not `O2` (depth 2)
 * The compiler checks it statically
 

--- a/courses/fundamentals_of_ada/140_access_types.rst
+++ b/courses/fundamentals_of_ada/140_access_types.rst
@@ -21,6 +21,10 @@ Access Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/160_genericity.rst
+++ b/courses/fundamentals_of_ada/160_genericity.rst
@@ -21,6 +21,10 @@ Genericity
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/170_tagged_derivation.rst
+++ b/courses/fundamentals_of_ada/170_tagged_derivation.rst
@@ -21,6 +21,10 @@ Tagged Derivation
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -21,6 +21,10 @@ Polymorphism
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/190_exceptions.rst
+++ b/courses/fundamentals_of_ada/190_exceptions.rst
@@ -21,6 +21,10 @@ Exceptions
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/230_interfacing_with_c.rst
+++ b/courses/fundamentals_of_ada/230_interfacing_with_c.rst
@@ -21,6 +21,10 @@ Interfacing with C
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/240_tasking.rst
+++ b/courses/fundamentals_of_ada/240_tasking.rst
@@ -21,6 +21,10 @@ Tasking
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/900_ada_version_comparison.rst
+++ b/courses/fundamentals_of_ada/900_ada_version_comparison.rst
@@ -21,6 +21,10 @@ Annex - Ada Version Comparison
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/915_predefined_libraries.rst
+++ b/courses/fundamentals_of_ada/915_predefined_libraries.rst
@@ -21,6 +21,10 @@ Annex - Predefined Libraries
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/920_reference_material.rst
+++ b/courses/fundamentals_of_ada/920_reference_material.rst
@@ -21,6 +21,10 @@ Annex - Reference Materials
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_030_basic_types.rst
+++ b/courses/fundamentals_of_ada/adv_030_basic_types.rst
@@ -21,6 +21,10 @@ Ada Basic Types - Advanced
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -21,6 +21,10 @@ Discriminated Record Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_065_primitives.rst
+++ b/courses/fundamentals_of_ada/adv_065_primitives.rst
@@ -21,6 +21,10 @@ Advanced Primitives
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_080_quantified_expressions.rst
+++ b/courses/fundamentals_of_ada/adv_080_quantified_expressions.rst
@@ -21,6 +21,10 @@ Quantified Expressions
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_090_overloading_equality.rst
+++ b/courses/fundamentals_of_ada/adv_090_overloading_equality.rst
@@ -21,6 +21,10 @@ Overloading Equality
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_120_advanced_privacy.rst
+++ b/courses/fundamentals_of_ada/adv_120_advanced_privacy.rst
@@ -21,6 +21,10 @@ Advanced Privacy
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_140_access_types.rst
+++ b/courses/fundamentals_of_ada/adv_140_access_types.rst
@@ -21,6 +21,10 @@ Advanced Access Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_170_multiple_inheritance.rst
+++ b/courses/fundamentals_of_ada/adv_170_multiple_inheritance.rst
@@ -21,6 +21,10 @@ Multiple Inheritance
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_190_exceptions.rst
+++ b/courses/fundamentals_of_ada/adv_190_exceptions.rst
@@ -21,6 +21,10 @@ Advanced Exceptions
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_240_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_240_tasking.rst
@@ -21,6 +21,10 @@ Advanced Tasking
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
+++ b/courses/fundamentals_of_ada/adv_245_ravenscar_tasking.rst
@@ -21,6 +21,10 @@ Ravenscar Tasking
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_250_containers.rst
+++ b/courses/fundamentals_of_ada/adv_250_containers.rst
@@ -21,6 +21,10 @@ Containers
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_260_controlled_types.rst
+++ b/courses/fundamentals_of_ada/adv_260_controlled_types.rst
@@ -21,6 +21,10 @@ Controlled Types
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_270_subprogram_contracts.rst
@@ -21,6 +21,10 @@ Subprogram Contracts
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_275_type_contracts.rst
+++ b/courses/fundamentals_of_ada/adv_275_type_contracts.rst
@@ -21,6 +21,10 @@ Type Contracts
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
+++ b/courses/fundamentals_of_ada/adv_280_low_level_programming.rst
@@ -21,6 +21,10 @@ Low Level Programming
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/labs/solar_system/050_array_types/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/050_array_types/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 4 - Array Types
+:title: Array Types - Lab
 :subtitle: The Sun, the Earth, the Moon and one Satellite
 
 The purpose of this exercise is to animate planets on the screen, one planet turning

--- a/courses/fundamentals_of_ada/labs/solar_system/060_record_types/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/060_record_types/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 5 - Records
+:title: Records - Lab
 :subtitle: The Satellite around the Earth
 
 The purpose of this exercise is to use records to store information about the celestial

--- a/courses/fundamentals_of_ada/labs/solar_system/070_subprograms/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/070_subprograms/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 6 - Subprograms
+:title: Subprograms - Lab
 :subtitle: A Simple Comet
 
 The purpose of this exercise is to animate the planets using subprograms.

--- a/courses/fundamentals_of_ada/labs/solar_system/100_packages/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/100_packages/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 7 - Packages
+:title: Packages - Lab
 :subtitle: The :code:`Solar_System` API
 
 The purpose of this exercise is to factor out the code for stars into a package.

--- a/courses/fundamentals_of_ada/labs/solar_system/110_private_types/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/110_private_types/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 8 - Privacy
+:title: Privacy - Lab
 :subtitle: The :code:`Solar_System` API is not working anymore
 
 The purpose of this exercise is to protect your API and make it more robust to users’

--- a/courses/fundamentals_of_ada/labs/solar_system/140_access_types/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/140_access_types/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 10 - Access
+:title: Access - Lab
 :subtitle: The :code:`Solar_System` API is still not working
 
 The purpose of this exercise is to use :ada:`Access` types to avoid passing

--- a/courses/fundamentals_of_ada/labs/solar_system/160_genericity/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/160_genericity/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 11 - Genericity
+:title: Genericity - Lab
 :subtitle: The Generic :code:`Solar_System` 
 
 The purpose of this exercise is to make our solar system generic

--- a/courses/fundamentals_of_ada/labs/solar_system/160_genericity_text/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/160_genericity_text/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 11 - Genericity
+:title: Genericity - Lab
 :subtitle: Introduction to generics
 
 The purpose of this exercise is to genericize some existing algorithms.

--- a/courses/fundamentals_of_ada/labs/solar_system/190_exceptions/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/190_exceptions/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 9 - Exceptions
+:title: Exceptions - Lab
 :subtitle: :code:`Solar_System` API collides!
 
 The purpose of this exercise is to use exceptions, for some original bodies physics.

--- a/courses/fundamentals_of_ada/labs/solar_system/230_interfacing_with_c/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/230_interfacing_with_c/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 29 - Interfaces
+:title: Interfaces - Lab
 :subtitle: The :code:`Solar_System` API is not working anymore
 
 The purpose of this exercise is to write a driver for the STM32F4

--- a/courses/fundamentals_of_ada/labs/solar_system/adv_170_multiple_inheritance/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/adv_170_multiple_inheritance/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 18 - Multiple Inheritance
+:title: Multiple Inheritance - Lab
 :subtitle: A true Object-Oriented :code:`Solar_System` 
 
 The purpose of this exercise is to rewrite the previous exercise using OOP.

--- a/courses/fundamentals_of_ada/labs/solar_system/adv_240_tasking_embedded/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/adv_240_tasking_embedded/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 22 - Tasking with interrupts
+:title: Tasking with interrupts - Lab
 :subtitle: The :code:`Solar_System` API is not working anymore
 
 The purpose of this exercise is to implement a handler on the button’s interrupt

--- a/courses/fundamentals_of_ada/labs/solar_system/adv_240_tasking_protected_objects/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/adv_240_tasking_protected_objects/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 22 - Tasking with Ravenscar
+:title: Tasking with Ravenscar - Lab
 :subtitle: The :code:`Solar_System` API with tasking
 
 The purpose of this exercise is to use Ravenscar tasks instead of one

--- a/courses/fundamentals_of_ada/labs/solar_system/adv_280_low_level_programming/instructions.rst
+++ b/courses/fundamentals_of_ada/labs/solar_system/adv_280_low_level_programming/instructions.rst
@@ -1,4 +1,4 @@
-:title: Lab 6 - Subprograms
+:title: Subprograms - Lab
 :subtitle: A Simple Comet
 
 The purpose of this exercise is to animate the planets using subprograms.

--- a/courses/fundamentals_of_ada/quiz/derivation_op_override/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/derivation_op_override/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/generic_subp_syntax/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/generic_subp_syntax/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/genericity_limited_type/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/genericity_limited_type/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/genericity_private_type/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/genericity_private_type/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/incomplete_type/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/incomplete_type/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/limited_constructor_syntax/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/limited_constructor_syntax/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/limited_extended_return/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/limited_extended_return/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/limited_operators/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/limited_operators/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/limited_private/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/limited_private/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/limited_syntax/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/limited_syntax/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/multiple_primitive/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/multiple_primitive/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/mutable_with_array/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/mutable_with_array/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/operators_override_simple/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/operators_override_simple/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/package_subprogram_completion/prj.gpr
+++ b/courses/fundamentals_of_ada/quiz/package_subprogram_completion/prj.gpr
@@ -1,0 +1,12 @@
+project Prj is
+   for Main use ("main.adb");
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj";
+
+   package Compiler is
+      for Default_Switches ("Ada") use ();
+   end Compiler;
+
+   package Builder is
+   end Builder;
+end Prj;

--- a/courses/fundamentals_of_ada/quiz/package_subprogram_completion/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/package_subprogram_completion/quiz.rst
@@ -1,0 +1,36 @@
+..
+    This file is auto-generated from the quiz template, it should not be modified
+    directly. Read README.md for more information.
+
+.. code:: Ada
+
+    package P is
+       Object_One : Integer;
+       procedure One (P : out Integer);
+    end P;
+
+Which completion(s) is(are) correct for :ada:`package P`?
+
+A. ``No completion is needed``
+B. | :answermono:`package body P is`
+   |    :answermono:`procedure One (P : out Integer) is null;`
+   | :answermono:`end P;`
+C. | ``package body P is``
+   |    ``Object_One : Integer;``
+   |    ``procedure One (P : out Integer) is``
+   |    ``begin``
+   |       ``P := Object_One;``
+   |    ``end One;``
+   | ``end P;``
+D. | :answermono:`package body P is`
+   |    :answermono:`procedure One (P : out Integer) is`
+   |    :answermono:`begin`
+   |       :answermono:`P := Object_One;`
+   |    :answermono:`end One;`
+   | :answermono:`end P;`
+
+.. container:: animate
+
+    A. Procedure One must have a body
+    B. Parameter P is :ada:`out` but not assigned
+    C. Redeclaration of Object_One

--- a/courses/fundamentals_of_ada/quiz/package_subprogram_completion/template/main.adb
+++ b/courses/fundamentals_of_ada/quiz/package_subprogram_completion/template/main.adb
@@ -1,0 +1,44 @@
+-- Which completion(s) is(are) correct for :ada:`package P`?
+procedure Main is
+   --$ begin question
+   package P is
+      Object_One : Integer;
+      procedure One (P : out Integer);
+   end P;
+   --$ end question
+   
+   --$ begin cut
+   No completion is needed
+   -- Procedure One must have a body
+   --$ end cut
+   
+   --$ begin cut
+   package body P is
+      procedure One (P : out Integer) is null;
+   end P;
+   -- Parameter P is :ada:`out` but not assigned
+   --$ end cut
+
+   --$ begin cut
+   package body P is
+      Object_One : Integer;
+      procedure One (P : out Integer) is
+      begin
+         P := Object_One;
+      end One;
+   end P;
+   -- Redeclaration of Object_One
+   --$ end cut
+
+   --$ begin cut
+   package body P is
+      procedure One (P : out Integer) is
+      begin
+         P := Object_One;
+      end One;
+   end P;
+   --$ end cut
+
+begin
+   null;
+end Main;

--- a/courses/fundamentals_of_ada/quiz/primitives_and_classwide/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/primitives_and_classwide/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/privacy_completion/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/privacy_completion/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/private_incomplete/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/private_incomplete/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/quantified_expr_equality/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/quantified_expr_equality/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/quantified_expr_syntax/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/quantified_expr_syntax/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/record_component_decl/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/record_component_decl/quiz.rst
@@ -13,7 +13,7 @@ Which record definition is legal?
 A. ``Component_1 : array (1 .. 3) of Boolean``
 B. :answermono:`Component_2, Component_3 : Integer`
 C. ``Component_1 : Record_T``
-D. ``Component_1 : constant Integer = 123``
+D. ``Component_1 : constant Integer := 123``
 
 .. container:: animate
 

--- a/courses/fundamentals_of_ada/quiz/record_component_decl/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/record_component_decl/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/record_component_decl/template/main.adb
+++ b/courses/fundamentals_of_ada/quiz/record_component_decl/template/main.adb
@@ -17,7 +17,7 @@ procedure Main is
       -- No recursive definition
       --$ end cut
       --$ begin cut
-      Component_1 : constant Integer = 123;
+      Component_1 : constant Integer := 123;
       -- No constant component
       --$ end cut
    --$ end question

--- a/courses/fundamentals_of_ada/quiz/tagged_dot_and_with/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/tagged_dot_and_with/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/tagged_primitives/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/tagged_primitives/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/user_defined_character/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/user_defined_character/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/variant_record_assignment_wrong_discriminant/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/variant_record_assignment_wrong_discriminant/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/quiz/variant_record_decl/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/variant_record_decl/quiz.rst
@@ -1,5 +1,4 @@
 ..
-
     This file is auto-generated from the quiz template, it should not be modified
     directly. Read README.md for more information.
 

--- a/courses/fundamentals_of_ada/spec_270_subprogram_contracts_ada95.rst
+++ b/courses/fundamentals_of_ada/spec_270_subprogram_contracts_ada95.rst
@@ -21,6 +21,10 @@ Subprogram Contracts
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_870_gnat_options.rst
+++ b/courses/fundamentals_of_ada/spec_870_gnat_options.rst
@@ -21,6 +21,10 @@ Annex - GNAT options
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
+++ b/courses/fundamentals_of_ada/spec_875_gpr_basics.rst
@@ -21,6 +21,10 @@ Annex - GPR Basics
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_880_elaboration.rst
+++ b/courses/fundamentals_of_ada/spec_880_elaboration.rst
@@ -21,6 +21,10 @@ Elaboration
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_890_ada_text_io.rst
+++ b/courses/fundamentals_of_ada/spec_890_ada_text_io.rst
@@ -21,6 +21,10 @@ Ada.Text_IO
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_891_ada_characters.rst
+++ b/courses/fundamentals_of_ada/spec_891_ada_characters.rst
@@ -21,6 +21,10 @@ Ada.Characters
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_892_ada_strings.rst
+++ b/courses/fundamentals_of_ada/spec_892_ada_strings.rst
@@ -21,6 +21,10 @@ Ada.Strings
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_893_ada_numerics.rst
+++ b/courses/fundamentals_of_ada/spec_893_ada_numerics.rst
@@ -21,6 +21,10 @@ Ada.Numerics
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/fundamentals_of_ada/spec_901_ada_2022_specific.rst
+++ b/courses/fundamentals_of_ada/spec_901_ada_2022_specific.rst
@@ -21,6 +21,10 @@ Ada 2022
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/010_overview.rst
+++ b/courses/gnat_project_facility/010_overview.rst
@@ -21,6 +21,10 @@ Overview
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/020_building_with_gprbuild.rst
+++ b/courses/gnat_project_facility/020_building_with_gprbuild.rst
@@ -21,6 +21,10 @@ Building with GPRbuild
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/030_project_properties.rst
+++ b/courses/gnat_project_facility/030_project_properties.rst
@@ -21,6 +21,10 @@ Project Properties
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/040_structuring_your_application.rst
+++ b/courses/gnat_project_facility/040_structuring_your_application.rst
@@ -21,6 +21,10 @@ Structuring Your Application
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/050_advanced_capabilities.rst
+++ b/courses/gnat_project_facility/050_advanced_capabilities.rst
@@ -21,6 +21,10 @@ Advanced Capabilities
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnat_project_facility/060_summary.rst
+++ b/courses/gnat_project_facility/060_summary.rst
@@ -21,6 +21,10 @@ Summary
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnatcheck/010_gnatcheck.rst
+++ b/courses/gnatcheck/010_gnatcheck.rst
@@ -21,6 +21,10 @@
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnatcoverage/010_gnatcoverage.rst
+++ b/courses/gnatcoverage/010_gnatcoverage.rst
@@ -21,6 +21,10 @@ GNATcoverage
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/gnattest/010_gnattest.rst
+++ b/courses/gnattest/010_gnattest.rst
@@ -21,6 +21,10 @@ GNATtest
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/10_advanced_proof.rst
+++ b/courses/spark_for_ada_programmers/10_advanced_proof.rst
@@ -21,6 +21,10 @@ Advanced Proof
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/11_advanced_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/11_advanced_flow_analysis.rst
@@ -21,6 +21,10 @@ Advanced Flow Analysis
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/12_pointer_programs.rst
+++ b/courses/spark_for_ada_programmers/12_pointer_programs.rst
@@ -21,6 +21,10 @@ Pointer Programs
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/13_autoactive_proof.rst
+++ b/courses/spark_for_ada_programmers/13_autoactive_proof.rst
@@ -21,6 +21,10 @@ Auto-active Proof
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/14_state_abstraction.rst
+++ b/courses/spark_for_ada_programmers/14_state_abstraction.rst
@@ -21,6 +21,10 @@ State Abstraction
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/15_spark_boundary.rst
+++ b/courses/spark_for_ada_programmers/15_spark_boundary.rst
@@ -21,6 +21,10 @@ SPARK Boundary
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/1_course_overview.rst
+++ b/courses/spark_for_ada_programmers/1_course_overview.rst
@@ -21,6 +21,10 @@ Course Overview
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
@@ -104,7 +104,7 @@ Formal Methods
   - Are applicable to **existing** development **artifacts** (models, code, etc.)
   - Are automated and integrated in **existing processes**
   - Provide value for **certification**
-  - Explicitely **encouraged** by some standards
+  - Explicitly **encouraged** by some standards
 
      + Railway (EN 50128)
      + Avionics (DO-178C + DO-333 Formal Methods Supplement)

--- a/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
@@ -21,6 +21,10 @@ Formal Methods and SPARK
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/3_spark_language.rst
+++ b/courses/spark_for_ada_programmers/3_spark_language.rst
@@ -21,6 +21,10 @@ SPARK Language
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/4_spark_tools.rst
+++ b/courses/spark_for_ada_programmers/4_spark_tools.rst
@@ -21,6 +21,10 @@ SPARK Tools
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/5_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/5_flow_analysis.rst
@@ -21,6 +21,10 @@ Flow Analysis
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/6_proof.rst
+++ b/courses/spark_for_ada_programmers/6_proof.rst
@@ -21,6 +21,10 @@ Proof
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/7_specification_language.rst
+++ b/courses/spark_for_ada_programmers/7_specification_language.rst
@@ -21,6 +21,10 @@ Specification Language
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/8_subprogram_contracts.rst
+++ b/courses/spark_for_ada_programmers/8_subprogram_contracts.rst
@@ -21,6 +21,10 @@ Subprogram Contracts
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/990_spark_example_project.rst
+++ b/courses/spark_for_ada_programmers/990_spark_example_project.rst
@@ -21,6 +21,10 @@ SPARK Example Project
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/spark_for_ada_programmers/9_type_contracts.rst
+++ b/courses/spark_for_ada_programmers/9_type_contracts.rst
@@ -21,6 +21,10 @@ Type Contracts
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/courses/static_analysis_via_compiler/010_static_analysis_via_compiler.rst
+++ b/courses/static_analysis_via_compiler/010_static_analysis_via_compiler.rst
@@ -21,6 +21,10 @@ Static Analysis Via Compiler
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols

--- a/support_files/prelude.rst
+++ b/support_files/prelude.rst
@@ -17,6 +17,10 @@
 .. |forall| replace:: :math:`\forall`
 .. |exists| replace:: :math:`\exists`
 .. |equivalent| replace:: :math:`\iff`
+.. |le| replace:: :math:`\le`
+.. |ge| replace:: :math:`\ge`
+.. |lt| replace:: :math:`<`
+.. |gt| replace:: :math:`>`
 
 ..
     Miscellaneous symbols


### PR DESCRIPTION
Major
- Base types: Add slide on numeric types conversion
- Records : Added very quick intro to limited (useful for classes without limited section)
- Subprograms: add example for default value
- Access: Rephrase access check rule, this version is probably less confusing

Minor (but impacting many files)
- Quiz: fix for comment that appeared in the slides, fix a typo `Integer = 123` -> `:=`
- Files preludes: added `|ge| |le| |gt| |lt|`
- Solar system labs: fix lab names
