### PR TITLE
Unconstrained type quiz and adv rework

### DIFF
--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -541,6 +541,73 @@ Quiz
    C. OK, same type and size
    D. OK, same type and size
 
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type My_Array is array (Boolean range <>) of Boolean;
+
+    O : My_Array (False .. False) := (others => True);
+
+What is the value of :ada:`O (True)`?
+
+A. :ada:`False`
+B. :ada:`True`
+C. None: Compilation error
+D. :answer:`None: Runtime error`
+
+.. container:: animate
+
+    :ada:`True` is not a valid index for :ada:`O`.
+
+    NB: GNAT will emit a warning by default.
+
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type My_Array is array (Integer range <>) of Boolean;
+
+    O : My_Array (0 .. -1) := (others => True);
+
+What is the value of :ada:`O'Length`?
+
+A. 1
+B. :answer:`0`
+C. None: Compilation error
+D. None: Runtime error
+
+.. container:: animate
+
+    Valid index for empty array, and :ada:`others` initialization allowed for empty range.
+
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type I_0 is range 0 .. 0;
+
+    type My_Array is array (I_0 range <>) of Boolean;
+
+How to declare an **empty** object of type :ada:`My_Array` ?
+
+A. ``O : My_Array (null);``
+B. ``O : My_Array (I_0'First .. I_0'First);``
+C. :answermono:`O : My_Array (I_0'First + 1 .. I_0'First);`
+D. ``O : My_Array (I_0'Last .. I_0'First);``
+
+.. container:: animate
+
+    For initializing empty arrays, index values out of the range are allowed.
+
+    NB: for enumerated index type, this may be impossible.
+
 ============
 Attributes
 ============

--- a/courses/fundamentals_of_ada/050_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types.rst
@@ -123,19 +123,22 @@ Kinds of Array Types
 * :dfn:`Constrained` Array Types
 
    - Bounds specified by type declaration
-   - All objects of the type have the same bounds
+   - **All** objects of the type have the same bounds
 
 * :dfn:`Unconstrained` Array Types
 
-   - Bounds not specified by type declaration
+   - Bounds not constrained by type declaration
+   - Objects share the type, but not the bounds
    - More flexible
-   - Allows having objects of the same type but different bounds
 
    .. code:: Ada
 
+      type Unconstrained is array (Positive range <>)
+        of Integer;
+
+      U1 : Unconstrained (1 .. 10);
       S1 : String (1 .. 50);
       S2 : String (35 .. 95);
-      S3 : String (1 .. 1024);
 
 =========================
 Constrained Array Types

--- a/courses/fundamentals_of_ada/060_record_types.rst
+++ b/courses/fundamentals_of_ada/060_record_types.rst
@@ -801,6 +801,89 @@ Mutable Discriminated Record
   S := (Group => Student, Gpa => 0.0);
   S := (Group => Faculty, Pubs => 10);
 
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type T (Sign : Integer) is record
+        case Sign is
+        when Integer'First .. -1 =>
+            I : Integer;
+            B : Boolean;
+        when others =>
+            N : Natural;
+        end case;
+    end record;
+
+    O : T (1);
+
+Which component does :ada:`O` contain?
+
+A. :ada:`O.I, O.B`
+B. :answermono:`O.N`
+C. None: Compilation error
+D. None: Runtime error
+
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type T (Floating : Integer) is record
+        case Floating is
+            when 0 =>
+                I : Integer;
+            when 1 =>
+                F : Float;
+        end case;
+    end record;
+
+    O : T (1);
+
+Which component does :ada:`O` contain?
+
+A. :ada:`O.F, O.I`
+B. :ada:`O.F`
+C. :answer:`None: Compilation error`
+D. None: Runtime error
+
+.. container:: animate
+
+    The variant :ada:`case` must cover all the possible values of :ada:`Integer`.
+
+------
+Quiz
+------
+
+.. code:: Ada
+
+    type T (Floating : Boolean) is record
+        case Floating is
+            when False =>
+                I : Integer;
+            when True =>
+                F : Float;
+        end case;
+        I2 : Integer;
+    end record;
+
+    O : T (True);
+
+Which component does :ada:`O` contain?
+
+A. :ada:`O.F, O.I2`
+B. :ada:`O.F`
+C. :answer:`None: Compilation error`
+D. None: Runtime error
+
+.. container:: animate
+
+    The variant part cannot be followed by a component declaration (:ada:`i2 : integer` there)
+
+
 ========
 Lab
 ========

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -39,7 +39,7 @@ Introduction
 Variant Record Types
 ----------------------
 
-* *Variant record type* is a record type where
+* :dfn:`Variant record type` is a record type where
 
    + Different objects may have different sets of components (i.e. different variants)
    + Given object itself may be *unconstrained*

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -349,7 +349,7 @@ Quiz
 .. include:: quiz/variant_record_decl/quiz.rst
 
 =======================
-Varying Length Arrays
+Unconstrained Arrays
 =======================
 
 ----------------------------------
@@ -376,15 +376,15 @@ Varying Lengths of Array Objects
    + Index for last valid element
 
 -----------------------------
-Simple Varying Length Array
+Simple Unconstrained Array
 -----------------------------
 
 .. code:: Ada
 
    type Simple_VString is
       record
-         Length : Natural range 0..Max_Length := 0;
-         Data   : String(1..Max_Length) := (others => ' ');
+         Length : Natural range 0 .. Max_Length := 0;
+         Data   : String (1 .. Max_Length) := (others => ' ');
       end record;
 
    function "&"(Left, Right : Simple_VString) return Simple_VString is
@@ -394,8 +394,8 @@ Simple Varying Length Array
          raise Constraint_Error;
       else
          Result.Length := Left.Length + Right.Length;
-         Result.Data(1..Result.Length) :=
-            Left.Data(1..Left.Length) & Right.Data(1..Right.Length);
+         Result.Data (1 .. Result.Length) :=
+            Left.Data (1 .. Left.Length) & Right.Data (1 .. Right.Length);
          return Result;
       end if;
    end "&";

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -409,7 +409,7 @@ Simple Varying Length Array
 * Issues
 
    + Every object has same maximum length
-   + `Length` needs to be maintained by program logic
+   + ``Length`` needs to be maintained by program logic
    + Need to define "="
 
 ------------------------------------------

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -109,10 +109,10 @@ Example Defined in Ada
          end case;
       end record;
 
-* `Group` value enforces component availability
+* :ada:`Group` value enforces component availability
 
-   + Can only access `GPA` and `Year` when `Group` is `Student`
-   + Can only access `Pubs` when `Group` is `Faculty`
+   + Can only access :ada:`GPA` and :ada:`Year` when :ada:`Group` is :ada:`Student`
+   + Can only access :ada:`Pubs` when :ada:`Group` is :ada:`Faculty`
 
 ------------------------
 Variant Part of Record
@@ -153,11 +153,11 @@ Discriminant in Ada Variant Records
 
 * When a component in a variant is selected, run-time check ensures that discriminant value is consistent with the selection
 
-   + If you could store into `Pubs` but read `GPA`, type safety would not be guaranteed
+   + If you could store into :ada:`Pubs` but read :ada:`GPA`, type safety would not be guaranteed
 
 * Ada prevents this type of access
 
-   + Discriminant (`Group`) established when object of type Person created
+   + Discriminant (:ada:`Group`) established when object of type Person created
    + Run-time check verifies that component selected from variant is consistent with discriminant value
 
       * Constraint_Error raised if the check fails
@@ -170,7 +170,7 @@ Discriminant in Ada Variant Records
 Semantics
 -----------
 
-* Variable of type `Person` is constrained by value of discriminant supplied at object declaration
+* Variable of type :ada:`Person` is constrained by value of discriminant supplied at object declaration
 
    + Determines minimal storage requirements
    + Limits object to corresponding variant
@@ -297,13 +297,13 @@ Unconstrained Variant Records
 Adding Flexibility to Variant Records
 ---------------------------------------
 
-* Previously, declaration of `Person` implies that object, once created, is always constrained by initial value of `Group`
+* Previously, declaration of :ada:`Person` implies that object, once created, is always constrained by initial value of :ada:`Group`
 
-   + Assigning `Person(Faculty)` to `Person(Student)` or vice versa, raises Constraint_Error
+   + Assigning :ada:`Person (Faculty)` to :ada:`Person (Student)` or vice versa, raises :ada:`Constraint_Error`
 
 * Additional flexibility is sometimes desired
 
-   + Allow declaration of unconstrained `Person`, to which either `Person(Faculty)` or `Person(Student)` can be assigned
+   + Allow declaration of unconstrained :ada:`Person`, to which either :ada:`Person (Faculty)` or :ada:`Person (Student)` can be assigned
    + To do this, *declare discriminant with default initialization*
 
 * Type safety is not compromised

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -48,8 +48,8 @@ Discriminated Record Types
 
    + Similar to :C:`union` in C
    + But preserves **type checking**
-   + And object size **depends** on discriminant
-
+   + And object size **is related to** discriminant
+    
 * Aggregate assignment is allowed
 
 -------------------------------------------

--- a/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
+++ b/courses/fundamentals_of_ada/adv_060_discriminated_record_types.rst
@@ -35,32 +35,26 @@ Discriminated Record Types
 Introduction
 ==============
 
-----------------------
-Variant Record Types
-----------------------
+----------------------------
+Discriminated Record Types
+----------------------------
 
-* :dfn:`Variant record type` is a record type where
+* :dfn:`Discriminated record` type
 
-   + Different objects may have different sets of components (i.e. different variants)
-   + Given object itself may be *unconstrained*
+   + Different **objects** may have **different** components
+   + All object **still** share the same type
 
-      * Different variants at different times
+* Kind of :dfn:`storage overlay`
 
-* Supported in other languages
+   + Similar to :C:`union` in C
+   + But preserves **type checking**
+   + And object size **depends** on discriminant
 
-   + Variant records in Pascal
-   + Unions in C
+* Aggregate assignment is allowed
 
-* Variant record offers a kind of storage overlaying
-
-   + Same storage might be used for one variant at one time, and then for another variant later
-   + Language issue: Ensure this does not provide loophole from type checking
-
-      * Neither Pascal nor C avoids this loophole
-
-------------------------------------
-Example Variant Record Description
-------------------------------------
+-------------------------------------------
+Example Discriminated Record Description
+-------------------------------------------
 
 * Record / structure type for a person
 
@@ -139,13 +133,13 @@ Variant Part of Record
 
       - Variant must be last part of record definition
 
-==========================
-Variant Record Semantics
-==========================
+================================
+Discriminated Record Semantics
+================================
 
--------------------------------------
-Discriminant in Ada Variant Records
--------------------------------------
+-------------------------------------------
+Discriminant in Ada Discriminated Records
+-------------------------------------------
 
 * Variant record type contains a special :dfn:`discriminant` component
 
@@ -289,13 +283,13 @@ Usage
      end loop;
    end Person_Test;
 
-===============================
-Unconstrained Variant Records
-===============================
+=====================================
+Unconstrained Discriminated Records
+=====================================
 
----------------------------------------
-Adding Flexibility to Variant Records
----------------------------------------
+---------------------------------------------
+Adding Flexibility to Discriminated Records
+---------------------------------------------
 
 * Previously, declaration of :ada:`Person` implies that object, once created, is always constrained by initial value of :ada:`Group`
 
@@ -312,9 +306,9 @@ Adding Flexibility to Variant Records
 
       * Either through copying an object or aggregate assignment
 
---------------------------------------
-Unconstrained Variant Record Example
---------------------------------------
+--------------------------------------------
+Unconstrained Discriminated Record Example
+--------------------------------------------
 
 .. code:: Ada
 
@@ -412,9 +406,9 @@ Simple Varying Length Array
    + ``Length`` needs to be maintained by program logic
    + Need to define "="
 
-------------------------------------------
-Varying Length Array via Variant Records
-------------------------------------------
+-------------------------------------------------
+Varying Length Array via Discriminated Records
+-------------------------------------------------
 
 * Discriminant can serve as bound of array component
 
@@ -430,9 +424,9 @@ Varying Length Array via Variant Records
    + With default discriminant value, objects can be copied even if lengths are different
    + With no default discriminant value, objects of different lengths cannot be copied
 
--------------------------------------------------------
-Varying Length Array via Variant Records and Subtypes
--------------------------------------------------------
+-------------------------------------------------------------
+Varying Length Array via Discriminated Records and Subtypes
+-------------------------------------------------------------
 
 * Discriminant can serve as bound of array component
 * Subtype serves as upper bound for :ada:`Size_T'Last`
@@ -463,9 +457,9 @@ Quiz
 
 .. include:: quiz/mutable_with_array/quiz.rst
 
-========================
-Variant Record Details
-========================
+==============================
+Discriminated Record Details
+==============================
 
 ------------------------------------
 Semantics of Discriminated Records
@@ -507,9 +501,9 @@ Lab
 Summary
 =========
 
-------------------------------------
-Properties of Variant Record Types
-------------------------------------
+------------------------------------------
+Properties of Discriminated Record Types
+------------------------------------------
 
 * Rules
 


### PR DESCRIPTION
Add quizzes to the basic slides for unconstrained arrays, and discriminated records.

The advanced discriminated record was using an old version of the slides, which had been rewritten, and was using the improper "Variant records" to mean RM-defined "discriminated records" and "varying length array" to mean RM-defined "unconstrained arrays".

This is based on the outdated #187 which I reworked and rebased onto master.
