### PR TITLE
CI: Fix deprecation warnings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,9 @@ jobs:
       # Black magic to generate the list of courses from the python script to JSON
       -
         id: set-courses
-        run: echo "::set-output name=courses::$(python3 contrib/ci/course.py find courses/ --json)"
+        run: |
+          courses="$(python3 contrib/ci/course.py find courses/ --json)"
+          echo "courses=$courses" >> $GITHUB_OUTPUT
 
     outputs:
         matrix: ${{steps.set-courses.outputs.courses}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -189,7 +189,7 @@ jobs:
           install_dir: ./cached_gnat
 
       - name: Setup Python
-        run: python3 -m pip install pytest git+https://gitlab.com/leogermond/epycs.git
+        run: python3 -m pip install pytest epycs
 
       - name: Run PyTest
         run: pytest --ignore=cached_gnat

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,7 +106,7 @@ jobs:
         run: python3 contrib/ci/package_labs.py courses/fundamentals_of_ada/mini_projects/cinema && unzip out/cinema/cinema.zip -d out/cinema/pkg
 
       - name: Mini Cinema - Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Mini Project - Mini Cinema
           path: out/cinema/pkg/*

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -124,6 +124,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/cache@v3
         with:
           path: ./cached_gnat
@@ -154,7 +156,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-
+        with:
+          python-version: '3.10'
       - name: Install black
         run: python3 -m pip install black
 
@@ -170,6 +173,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/cache@v3
         with:
           path: ./cached_gnat


### PR DESCRIPTION
Only warning that remains is related to using the GNAT CE action, which will be fixed with #277 