### PR TITLE
Update SPARK course material for SPARK Pro 24

### DIFF
--- a/courses/spark_for_ada_programmers/10_advanced_proof.rst
+++ b/courses/spark_for_ada_programmers/10_advanced_proof.rst
@@ -76,11 +76,15 @@ Going Beyond Basic Proof
   - Ability to partially initialize variables
   - Proof deals with initialization of such variables
 
+|
+
 * Loop pragmas
 
   - Specialized pragmas to deal with loops in proof
   - Loop invariants provide the necessary help
   - Loop variants deal with loop termination
+
+|
 
 * SPARK formal containers
 
@@ -98,6 +102,8 @@ Limitations of the Initialization Policy
 
   - Forces useless initialization of unread components
 
+|
+
 * Arrays must be initialized from an aggregate
 
   - Otherwise flow analysis cannot check initialization
@@ -105,6 +111,8 @@ Limitations of the Initialization Policy
   - Except in some special cases when a heuristic works
 
     + e.g. fully initialize an array with a *for loop*
+
+|
 
 * All outputs must be fully initialized when returning
 
@@ -372,11 +380,15 @@ Loop Frame Condition (1/2)
   - All information on modified variables is lost
   - Except information preserved in the loop invariant
 
+|
+
 * This is true for the :dfn:`loop frame condition`
 
   - Variables that are not modified
   - Parts of modified variables that are preserved
   - Similar to frame condition on subprogram calls
+
+|
 
 * :toolname:`GNATprove` generates part of the frame condition
 
@@ -426,6 +438,8 @@ Classical Loop Invariants
   - Maximize loops - search element that maximizes a property
   - Update loops - update each element of the collection
 
+|
+
 * SPARK User's Guide gives detailed loop invariants
 
   - See section *7.9.2 Loop Examples*
@@ -468,15 +482,21 @@ Loop Variants (1/2)
   - Executed specially at runtime
   - Interpreted specially in proof
 
+|
+
 * Dynamic checks inserted by GNAT
 
   - When using switch :command:`-gnata`
   - Or pragma :ada:`Assertion_Policy (Loop_Variant => Check)`
   - Check that expression varies as indicated at each iteration
 
+|
+
 * Only one loop variant is needed to prove loop termination
 
   - And only on *while loop* or *plain loop*, not on *for loop*
+
+|
 
 * Same placement as for loop invariants
 
@@ -518,8 +538,9 @@ Formal Containers in SPARKlib
 * Available from SPARK Library
 
   - Distributed with SPARK Pro
-  - To use, add :code:`with "sparklib";` in project file
-  - Also need to define env var :code:`SPARKLIB_OBJECT_DIR`
+  - Copy :filename:`sparklib.gpr` or :filename:`sparklib_light.gpr` locally
+  - Set value of :code:`Object_Dir` in the copied project file
+  - To use, add :code:`with "sparklib[_light]";` in your project file
 
 * Reminder: four kinds of formal containers
 
@@ -612,6 +633,8 @@ Loop Invariants Over Formal Containers
 
   - Use scalar index :ada:`J` to access vector at :ada:`V.Element (J)`
 
+|
+
 * Iteration over positions
 
   - For vectors, same as range-based iteration (cursor is index)
@@ -620,6 +643,8 @@ Loop Invariants Over Formal Containers
     + Functional model of the container
     + Mapping from cursors to positions
     + Sequence of elements/keys of the container
+
+|
 
 * Iteration over elements
 
@@ -667,11 +692,15 @@ Difficulties With Loops Over Formal Containers
 
 * :toolname:`GNATprove` does not unroll such loops
 
+|
+
 * :toolname:`GNATprove` does not generate a frame condition
 
   - Contrary to loops over arrays
   - Need to explicitly state the frame condition using attribute
     :ada:`Loop_Entry`
+
+|
 
 * Container structure may be modified in the loop
 
@@ -723,7 +752,7 @@ Advanced Proof
 
 * Use relaxed initialization when needed
 
-  - Some variable are partially initialized
+  - Some variables are partially initialized
   - Some array variables are initialized in a loop
   - More annotations are needed with attribute :ada:`Initialized`
 

--- a/courses/spark_for_ada_programmers/11_advanced_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/11_advanced_flow_analysis.rst
@@ -214,10 +214,14 @@ From Data Dependencies
 
 * Data dependencies may be specified or generated
 
+|
+
 * If flow dependencies are not specified, they are generated
 
   - All outputs depend on all inputs
   - All globals of mode :ada:`Proof_In` have no effect on outputs
+
+|
 
 * This is a correct over-approximation of actual flow dependencies
 
@@ -230,11 +234,15 @@ From Flow Dependencies
 
 * If only flow dependencies are specified
 
+|
+
 * Data dependencies are generated
 
   - All variables only on the left-hand side are outputs
   - All variables only on the right-hand side are inputs
   - All other variables are both inputs and outputs
+
+|
 
 * This is the exact data dependencies consistent with flow dependencies
 

--- a/courses/spark_for_ada_programmers/12_pointer_programs.rst
+++ b/courses/spark_for_ada_programmers/12_pointer_programs.rst
@@ -45,7 +45,11 @@ Absence of Interferences
   - Between a parameter and a global variable
   - ... when that may lead to interferences
 
+|
+
 * Interferences when one of the variables is written
+
+|
 
 * Many features avoid direct use of pointers
 
@@ -53,6 +57,8 @@ Absence of Interferences
   - By-reference parameter passing mode
   - Address specifications :ada:`X : Integer with Address => ...`
   - Generics (avoid C-style :code:`void*` genericity)
+
+|
 
 * What about pointers?
 
@@ -64,10 +70,14 @@ Pointers and Aliasing
 
   - This violates SPARK principle of absence of interferences
 
+|
+
 * Rust programming language popularized :dfn:`ownership`
 
   - Only one pointer (the *owner*) at any time has read-write access
   - Assigning a pointer transfers its ownership
+
+|
 
 * Work on ownership in SPARK started in 2017
 
@@ -250,9 +260,13 @@ Access to Constant Data
   - Pointers in that data inherit the same property
   - This is specific to SPARK: in Ada only designated data is constant
 
+|
+
 * Also applies to constants and input parameters of composite types containing pointers
 
   - Different from constants and input parameters of access-to-variable type
+
+|
 
 * Aliasing is allowed
 
@@ -265,9 +279,15 @@ Access to Data on the Stack
   - Not allowed on global variable which would remain visible
   - Result of general access type with :ada:`access all` syntax
 
+|
+
 * :ada:`Constant'Access` of access-to-constant type
 
+|
+
 * :ada:`Variable'Access` of access-to-variable type
+
+|
 
 * Variable is *moved* and cannot be referenced anymore
 
@@ -297,14 +317,20 @@ Useful Tips
 
 * No cycles or sharing inside mutable data structures
 
+|
+
 * Global objects can also be moved temporarily
 
   - Procedure must restore some value (or null) before returning
+
+|
 
 * Allocation function returns a new object of access-to-variable type
 
   - Similar to initialized allocator with :ada:`new T'(Value)`
   - Some special *traversal functions* give access to part of an object
+
+|
 
 * Deallocation procedure simply nullifies in-out access parameter
 
@@ -358,7 +384,6 @@ Pointers and Recursion
   .. code:: ada
 
      function All_List_Zero ... with
-       Annotate => (GNATprove, Always_Return),
        Subprogram_Variant => (Structural => L);
 
 --------------------
@@ -438,6 +463,8 @@ Pointers with Aliasing (1/2)
   - :ada:`SPARK.Pointers.Pointers_With_Aliasing_Separate_Memory`
   - Only generic parameter is any type :ada:`Object`
 
+|
+
 * Both allow aliasing pointers
 
   - Type :ada:`Pointer` is private
@@ -448,7 +475,7 @@ Pointers with Aliasing (1/2)
   - All accesses through API check validity of pointer
 
 ------------------------------
-Pointers with Aliasing (1/2)
+Pointers with Aliasing (2/2)
 ------------------------------
 
 * Shared API to create, free, access pointers

--- a/courses/spark_for_ada_programmers/13_autoactive_proof.rst
+++ b/courses/spark_for_ada_programmers/13_autoactive_proof.rst
@@ -1,5 +1,5 @@
 *******************
-Auto-active Proof
+Auto-Active Proof
 *******************
 
 ..
@@ -450,10 +450,14 @@ Ghost Functions
 
 * Most common ghost entities
 
+|
+
 * Ghost functions express properties used in contracts
 
   - Typically as expression functions
   - Complete the existing API with queries only for verification
+
+|
 
 * Ghost functions can be very costly in running time
 

--- a/courses/spark_for_ada_programmers/14_state_abstraction.rst
+++ b/courses/spark_for_ada_programmers/14_state_abstraction.rst
@@ -76,9 +76,15 @@ Dependency Contracts and Information Hiding
   - In data dependencies with aspect :ada:`Global`
   - In flow dependencies with aspect :ada:`Depends`
 
+|
+
 * These variables need to be visible
 
+|
+
 * Information hiding forbids exposing variables
+
+|
 
 * Solution is to use :dfn:`state abstraction`
 
@@ -340,7 +346,11 @@ Dependency Refinement
     + Aspect :ada:`Refined_Global` for data dependencies
     + Aspect :ada:`Refined_Depends` for flow dependencies
 
+|
+
 * :toolname:`GNATprove` verifies these specifications when present
+
+|
 
 * :toolname:`GNATprove` generates those refined contracts otherwise
 

--- a/courses/spark_for_ada_programmers/15_spark_boundary.rst
+++ b/courses/spark_for_ada_programmers/15_spark_boundary.rst
@@ -44,10 +44,14 @@ Modelling the System
   - Usually marked as volatile for the compiler
   - This prevents compiler optimizations
 
+|
+
 * :toolname:`GNATprove` needs to model these interactions
 
   - Both in flow analysis and proof
   - Distinction between different kinds of interactions
+
+|
 
 * This modelling is used as assumptions by :toolname:`GNATprove`
 
@@ -63,9 +67,15 @@ Integrating SPARK Code
   - Some services (logging, input/output) may not be in SPARK
   - Only a core part may be in SPARK
 
+|
+
 * User needs to specify the boundary of SPARK code
 
+|
+
 * :toolname:`GNATprove` needs to model interactions with non-SPARK code
+
+|
 
 * GNAT needs to compile SPARK and non-SPARK code together
 
@@ -134,6 +144,8 @@ Volatility Properties
   - :ada:`Effective_Reads` - reading the variable changes its value
   - :ada:`Effective_Writes` - writing the variable changes its value
 
+|
+
 * Each is a Boolean aspect of volatile variables
 
   - By default a volatile variable has all four set to :ada:`True`
@@ -147,14 +159,20 @@ Volatility Properties - Examples
 
   - :ada:`Async_Writers => True`
 
+|
+
 * An actuator (program output) has aspect
 
   - :ada:`Async_Readers => True`
+
+|
 
 * A machine register (single data) has aspects
 
   - :ada:`Effective_Reads => False`
   - :ada:`Effective_Writes => False`
+
+|
 
 * A serial port (stream of data) has aspects
 
@@ -192,6 +210,8 @@ External State
 
   - Abstract state needs to have aspect :ada:`External`
 
+|
+
 * An external state is subject to the four volatility properties
 
   - All volatility properties set to :ada:`True` by default
@@ -200,6 +220,8 @@ External State
 
     + Non-volatile constituents
     + Volatile constituents with :ada:`Prop` set to :ada:`False`
+
+|
 
 * Special case for external state always initialized
 
@@ -264,12 +286,18 @@ Identifying SPARK Code
 * SPARK code is identified by pragma/aspect :ada:`SPARK_Mode` with value
   :ada:`On`
 
+|
+
 * Other values: :ada:`Off` or :ada:`Auto`
 
   - :ada:`Off` to exclude code
   - :ada:`Auto` to include only SPARK-compatible declarations (not bodies)
 
+|
+
 * Default is :ada:`On` when using :ada:`SPARK_Mode` without value
+
+|
 
 * Default is :ada:`Auto` when :ada:`SPARK_Mode` not specified
 
@@ -284,12 +312,16 @@ Sections with :ada:`SPARK_Mode`
   - :ada:`SPARK_Mode` can be :ada:`On` for spec then :ada:`On` or
     :ada:`Off` for body
 
+|
+
 * Packages can have between 1 and 4 sections:
 
   - package spec visible and private parts, package body declarations and
     statements
   - :ada:`SPARK_Mode` can be :ada:`On` for some sections then :ada:`On` or
     :ada:`Off` for the remaining sections
+
+|
 
 * :ada:`SPARK_Mode` **cannot** be :ada:`Off` for a section
 
@@ -304,6 +336,8 @@ Inheritance for :ada:`SPARK_Mode` on Subprogram
 
   - Nested subprogram or package can have :ada:`SPARK_Mode` with value
     :ada:`Off`
+
+|
 
 * Value for subprogram spec **not** inherited for subprogram body
 
@@ -440,9 +474,15 @@ Integrating SPARK and Ada Code
 
 * SPARK code has :ada:`SPARK_Mode` with value :ada:`On`
 
+|
+
 * Ada code has no :ada:`SPARK_Mode` or with value :ada:`Off`
 
+|
+
 * GNAT compiles all code together
+
+|
 
 * Contracts on Ada subprograms must be correct
 
@@ -544,10 +584,14 @@ Modelling an API
   - Implementation may be in Ada, C, Rust...
   - Implementation may be in the Operating System
 
+|
+
 * Relevant global data should be modelled
 
   - As abstract states when not accessed concurrently
   - As external states when accessed concurrently
+
+|
 
 * API subprogram contracts model actual behavior
 

--- a/courses/spark_for_ada_programmers/1_course_overview.rst
+++ b/courses/spark_for_ada_programmers/1_course_overview.rst
@@ -42,7 +42,7 @@ Styles
 * :dfn:`This` is a definition
 * :filename:`this/is/a.path`
 * :ada:`code is highlighted`
-* :command:`commands are emphasised --like-this`
+* :command:`commands are emphasized --like-this`
 * :menu:`This` |rightarrow| :menu:`Is` |rightarrow| :menu:`An IDE Menu`
 
 ==================
@@ -123,6 +123,8 @@ Formal Verification Goals
   - Modular (analyzes modules in parallel)
   - Constructive (works on incomplete programs)
 
+|
+
 * SPARK is designed with these goals in mind. Since the eighties!
 
   - But the language and tools have evolved considerably...
@@ -201,7 +203,7 @@ Course Outline
     * Advanced topics
 
        - Pointer Programs
-       - Auto-active Proof
+       - Auto-Active Proof
        - State Abstraction
 
     * SPARK Boundary

--- a/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
+++ b/courses/spark_for_ada_programmers/2_formal_methods_and_spark.rst
@@ -217,7 +217,9 @@ Abstract Interpretation
   - If the values of :ada:`Table`, :ada:`A`, :ada:`B` are precise enough,
     AbsInt can deduce that :ada:`Idx in Table'Range`
 
-  - Otherwise, an :dfn:`alarm` is emitted (for sound analysis)
+  - Otherwise, an **alarm** is emitted (for sound analysis)
+
+|
 
 * Initialization and value of individual array cells is **not** tracked
 
@@ -238,7 +240,9 @@ Symbolic Execution and Bounded Model Checking
   - If the values of :ada:`A` and :ada:`B` are *close enough*, SymExe/BMC can
     analyze all loop iterations and deduce that :ada:`Idx in Table'Range`
 
-  - Otherwise, an alarm is emitted (for sound analysis)
+  - Otherwise, an **alarm** is emitted (for sound analysis)
+
+|
 
 * Analysis of loops is limited to few iterations (same for recursion)
 
@@ -256,7 +260,7 @@ Deductive Verification
 
   - Predicate defined by the user which restricts the calling context
   - Proof checks if the precondition entails :ada:`Idx in Table'Range`
-  - Otherwise, an alarm is emitted
+  - Otherwise, an **alarm** is emitted
 
 * Initialization and value of individual array cells is tracked
 * Analysis of loops is based on user-provided :dfn:`loop invariants`
@@ -314,6 +318,8 @@ SPARK is a Language Subset
     + e.g. arbitrary aliasing of pointers, dispatching calls in
       OOP
 
+|
+
 * SPARK hits the **sweet spot** for proof
 
   - Based on strongly typed feature-rich Ada programming language
@@ -322,6 +328,8 @@ SPARK is a Language Subset
     1. Simplify user's effort for annotating the code
 
     2. Simplify the job of automatic provers
+
+|
 
 * "SPARK" originally stands for "SPADE Ada Ratiocinative Kernel"
 
@@ -335,12 +343,15 @@ History of SPARK
   - SPARK 95 based on Ada 95
   - SPARK 2005 based on Ada 2005
 
+|
+
 * Since 2014, *SPARK* is updated annually
 
   - OO programming added in 2015
   - Concurrency added in 2016
   - Type invariants added in 2017
   - Pointers added in 2019
+  - Exceptions added in 2023
 
 ============================
 Applying SPARK in Practice
@@ -351,6 +362,9 @@ Levels of Software Assurance
 ------------------------------
 
 * Various reasons for using SPARK
+
+|
+
 * Levels of software assurance
 
   1. **Stone level** - valid SPARK
@@ -363,7 +377,12 @@ Levels of Software Assurance
 
   5. **Platinum level** - full functional proof of requirements
 
+|
+
 * Higher levels are more costly to achieve
+
+|
+
 * Higher levels build on lower levels
 
   - Project can decide to move to higher level later

--- a/courses/spark_for_ada_programmers/3_spark_language.rst
+++ b/courses/spark_for_ada_programmers/3_spark_language.rst
@@ -152,14 +152,13 @@ Excluded Ada Features
 
   - Can create loops, which require a specific treatment in formal verification
 
+|
+
 * Controlled types
 
   - Creates complex control flow with implicit calls
 
-* Exception handlers
-
-  - Creates complex control flow across calls
-  - **Raising** exceptions is **allowed**
+|
 
 * Tasking features: :ada:`accept` statement (aka :dfn:`rendezvous`),
   :ada:`requeue` statement, :ada:`select` statement, etc
@@ -175,6 +174,9 @@ Support for Generics
 ----------------------
 
 * Only **instances** of generics are analyzed
+
+|
+
 * Analysis of generics themselves would require:
 
   - Extending the SPARK language with new specifications
@@ -183,6 +185,8 @@ Support for Generics
     + To add dependency contracts to formal subprogram parameters
 
   - More efforts from users to annotate programs
+
+|
 
 * **No restrictions** regarding use of generics
 
@@ -265,6 +269,8 @@ Functions Without Side-Effects
   - Writing to an :ada:`out` or :ada:`in out` parameter
   - Reading a volatile variable
 
+|
+
 * But :dfn:`volatile functions` can read a volatile variable
 
   - Details discussed in the course on SPARK Boundary
@@ -301,9 +307,13 @@ Benefits of Functions Without Side-Effects
   - **Unambiguous** evaluation of expressions
   - Simplifies both flow analysis and proof
 
+|
+
 * Specifications and assertions have no side-effects
 
   - As specifications and assertions are expressions
+
+|
 
 * SPARK functions are **mathematical functions** from inputs to a result
 
@@ -319,10 +329,14 @@ Absence of Interferences
   - and the code writes to :ada:`A`, then reads :ada:`B`
   - or the code writes to :ada:`A` and to :ada:`B`
 
+|
+
 * Interferences are caused by passing parameters
 
   - Parameter and global variable may designate the same object
   - Two parameters may designate the same object
+
+|
 
 * Thus no interferences on function calls!
 
@@ -390,11 +404,15 @@ Benefits of Absence of Interferences
 
   - **Simplifies** both flow analysis and proof
 
+|
+
 * No need for users to add specifications about separation
 
   - Between parameters and global variables
   - Between parameters themselves
   - Between parts of objects (one could be a part of another)
+
+|
 
 * Program behavior does not depend on parameter-passing mechanism
 

--- a/courses/spark_for_ada_programmers/4_spark_tools.rst
+++ b/courses/spark_for_ada_programmers/4_spark_tools.rst
@@ -126,6 +126,8 @@ Debugging SPARK Code
 
   - Code should be compiled with :command:`-g -O0`
 
+|
+
 * Assertions can be debugged **too**!
 
   - Code should be compiled with :command:`-gnata`
@@ -231,6 +233,8 @@ Adapting the Project File for Analysis
 Structure of :toolname:`GNATprove`
 ------------------------------------
 
+|
+
 .. image:: spark_structure.png
 
 .. container:: speakernote
@@ -308,8 +312,8 @@ Categories of Messages
 * :dfn:`Check messages` start with severity :command:`high:`,
   :command:`medium:` or :command:`low:`
 
-  - With switch :command:`--checks-as-errors`, :toolname:`GNATprove` exits with
-    error status
+  - With switch :command:`--checks-as-errors=on`, :toolname:`GNATprove` exits
+    with error status
 
 * :dfn:`Warnings` start with :command:`warning:`
 

--- a/courses/spark_for_ada_programmers/5_flow_analysis.rst
+++ b/courses/spark_for_ada_programmers/5_flow_analysis.rst
@@ -277,6 +277,8 @@ Generation of Data Dependency Contracts
   - Using either specified or generated contracts for calls
   - More precise generation for SPARK code than for Ada code
 
+|
+
 * Generated contract may be imprecise
 
   - Output may be computed as both input and output
@@ -374,7 +376,8 @@ Analysis of Array Initialization (1/2)
 
      type T is array (1 .. 10) of Boolean;
 
-     procedure Init_Array (A : out T) is -- Initialization check fails
+     -- Initialization check fails
+     procedure Init_Array (A : out T) is
      begin
         A (1) := True;
         A (2 .. 10) := (others => False);

--- a/courses/spark_for_ada_programmers/6_proof.rst
+++ b/courses/spark_for_ada_programmers/6_proof.rst
@@ -420,7 +420,12 @@ Contextual Analysis of Local Subprograms
   - Without contracts: no :ada:`Global`, :ada:`Pre`, :ada:`Post`, etc.
   - Additional conditions, details in the SPARK User's Guide
 
+|
+
 * Benefit: no need to add a contract
+
+|
+
 * Possible cost: proof of caller may become more complex
 
   - Add explicit contract like :ada:`Pre => True` to disable inlining of a
@@ -614,7 +619,8 @@ Dealing with False Alarms
 
   - :ada:`Reason` is a string literal for reviews
 
-    + Reason is repeated in analysis summary file :filename:`gnatprove.out`
+    + Reason is repeated in output with switch :command:`--report=all` and in
+      analysis summary file :filename:`gnatprove.out`
 
 * Justification inserted immediately after the check message location
 

--- a/courses/spark_for_ada_programmers/7_specification_language.rst
+++ b/courses/spark_for_ada_programmers/7_specification_language.rst
@@ -46,13 +46,13 @@ Simple Expressions
 
     .. code:: ada
 
-       I in T'Range
+          I in T'Range
 
     is better than:
 
     .. code:: ada
 
-       I >= T'First and I <= T'Last
+          I >= T'First and I <= T'Last
 
   - Conjunctions and disjunctions
 
@@ -409,7 +409,7 @@ Expression Functions
 
 * Convenient shorthand for **repeated** subexpression
 
-  - Somewhat similar goal as delta expressions
+  - Somewhat similar goal as declare expressions
   - But visible in a **larger** scope
 
 * Simple query functions used in contracts

--- a/courses/spark_for_ada_programmers/8_subprogram_contracts.rst
+++ b/courses/spark_for_ada_programmers/8_subprogram_contracts.rst
@@ -239,6 +239,8 @@ Attribute :ada:`Old`
 
   - Forbidden on :ada:`limited` types
 
+|
+
 * Evaluation for the copy may raise runtime errors
 
   - Not allowed by default inside *potentially unevaluated expressions*
@@ -253,6 +255,8 @@ Attribute :ada:`Old`
          with Post =>
            (if J in A'Range then V = A (J)'Old); -- Illegal
 
+  |
+
   - Use :ada:`pragma Unevaluated_Use_Of_Old (Allow)` to allow
 
     + :toolname:`GNATprove` **checks** that this is safe
@@ -264,6 +268,8 @@ Special Cases for Attribute :ada:`Old`
 * Simple component access :ada:`X.C'Old` equivalent to :ada:`X'Old.C`
 
   - Although one may be more efficient at runtime
+
+|
 
 * Function call in the prefix of :ada:`Old` is evaluated at subprogram entry
 
@@ -316,9 +322,13 @@ Contract Cases (2/2)
   - Note: guards are evaluated **on entry**
   - Attributes :ada:`Old` and :ada:`Result` allowed in consequence
 
+|
+
 * :toolname:`GNATprove` checks that cases are **disjoint** and **complete**
 
   - All inputs allowed by the precondition are covered by a single case
+
+|
 
 * When enabled at runtime:
 
@@ -505,13 +515,14 @@ What's wrong with the following code?
 Terminating Functions
 -----------------------
 
-* **All** functions should terminate
+* Functions should **always** terminate
 
-  - Specific annotation to require proof of termination
+* Specific contract to require proof of termination of procedures
 
   .. code:: ada
 
-     Annotate => (GNATprove, Always_Return)
+     procedure P
+       with Always_Terminates => Condition;
 
 * Flow analysis proves termination in **simple cases**
 

--- a/courses/spark_for_ada_programmers/9_type_contracts.rst
+++ b/courses/spark_for_ada_programmers/9_type_contracts.rst
@@ -102,6 +102,8 @@ Richer Type Contracts
 
   - Using the aspect syntax for :ada:`Predicate` and :ada:`Type_Invariant`
 
+|
+
 * Language support goes **much beyond** contracts-as-a-library
 
   - Constraint expressed once and verified *everywhere*
@@ -111,6 +113,8 @@ Richer Type Contracts
 
        pragma Assertion_Policy (Predicate => Check);
        pragma Assertion_Policy (Type_Invariant => Ignore);
+
+|
 
 * :toolname:`GNATprove` analysis based on contracts
 
@@ -165,14 +169,20 @@ Static vs Dynamic Predicate
   - Usable mostly on scalar and enumeration types
   - That does **not** mean statically checked by the compiler
 
+|
+
 * **Dynamic** predicates are **arbitrary** boolean expressions
 
   - Applicable to array and record types
+
+|
 
 * Types with static predicates are allowed in more contexts
 
   - Used as range in a *for loop*
   - Used as choice in *case statement* or *case expression*
+
+|
 
 * Aspect :ada:`Predicate` is GNAT name for:
 
@@ -294,9 +304,11 @@ Restrictions in Usage
     + Use instead attributes :ada:`First_Valid` and :ada:`Last_Valid`
     + Not allowed on type with dynamic predicate
 
+|
+
 * Type with dynamic predicate further restricted
 
-  - Not allowed as range in a :ada:`for in ... loop`
+  - Not allowed as range in a *for loop*
   - Not allowed as choice in *case statement* or *case expression*
 
 --------------------------------
@@ -308,16 +320,22 @@ Dynamic Checking of Predicates
   - When using switch :command:`-gnata`
   - Or pragma :ada:`Assertion_Policy (Predicate => Check)`
 
+|
+
 * Placement of checks **similar** as for type constraints
 
   - On assignment and initialization
   - On conversion :ada:`T(...)` and qualification :ada:`T'(...)`
   - On parameter passing in a call
 
+|
+
 * No checks where not needed
 
   - On uninitialized objects
   - On references to an object
+
+|
 
 * No checks where that would be too expensive
 
@@ -331,15 +349,21 @@ Static Checking of Predicates
 
   - Always (independent of the choice of switches or pragmas)
 
+|
+
 * Placement of checks as for dynamic checks
 
   - Plus assignment on part of the object
   - :toolname:`GNATprove` checks objects **always** satisfy their predicate
 
+|
+
 * No checks only where not needed
 
   - On uninitialized objects
   - On references to an object
+
+|
 
 * :toolname:`GNATprove` can assume that all initialized objects satisfy their
   type constraints and predicates
@@ -381,7 +405,7 @@ Type Invariants
 What is a Type Invariant?
 ---------------------------
 
-* :ada:`Boolean` property that should always hold of objects of the type
+* Boolean property that should always hold of objects of the type
 
   - ...**outside** of its unit
   - Same use of name of the type and component names as in predicates

--- a/courses/spark_for_ada_programmers/labs/10_advanced_proof.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/10_advanced_proof.lab.rst
@@ -6,9 +6,7 @@ Advanced Proof Lab
 
    + You can copy it locally, or work with it in-place
 
-- Define variable :code:`SPARKLIB_OBJECT_DIR` to have value :code:`\$PWD/obj` in the environment
-
-  - For example with bash/zsh: :command:`export SPARKLIB_OBJECT_DIR=\$PWD/obj`
+- Copy locally :finename:`sparklib.gpr` from your SPARK install and set :code:`Object_Dir`
 
 - In that directory, open the project :filename:`lab.gpr` in :toolname:`GNAT Studio`
 

--- a/courses/spark_for_ada_programmers/labs/12_pointer_programs.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/12_pointer_programs.lab.rst
@@ -6,9 +6,7 @@ Pointer Programs Lab
 
    + You can copy it locally, or work with it in-place
 
-- Define variable :code:`SPARKLIB_OBJECT_DIR` to have value :code:`\$PWD/obj` in the environment
-
-  - For example with bash/zsh: :command:`export SPARKLIB_OBJECT_DIR=\$PWD/obj`
+- Copy locally :finename:`sparklib.gpr` from your SPARK install and set :code:`Object_Dir`
 
 - In that directory, open the project :filename:`lab.gpr` in :toolname:`GNAT Studio`
 

--- a/courses/spark_for_ada_programmers/labs/13_autoactive_proof.lab.rst
+++ b/courses/spark_for_ada_programmers/labs/13_autoactive_proof.lab.rst
@@ -6,9 +6,7 @@ Auto-active Proof Lab
 
    + You can copy it locally, or work with it in-place
 
-- Define variable :code:`SPARKLIB_OBJECT_DIR` to have value :code:`\$PWD/obj` in the environment
-
-  - For example with bash/zsh: :command:`export SPARKLIB_OBJECT_DIR=\$PWD/obj`
+- Copy locally :finename:`sparklib.gpr` from your SPARK install and set :code:`Object_Dir`
 
 - In that directory, open the project :filename:`lab.gpr` in :toolname:`GNAT Studio`
 


### PR DESCRIPTION
The following changes are taken into account:
- checking function termination is now the default
- annotation Always_Returns has been replaced by aspect Always_Terminates
- exception handlers are now supported
- SPARKlib now requires copying and adapting the project file

Also introduce space when possible between bullet points.