### PR TITLE
Use "class-wide" instead of "classwide" or "class wide"

### DIFF
--- a/courses/fundamentals_of_ada/180_polymorphism.rst
+++ b/courses/fundamentals_of_ada/180_polymorphism.rst
@@ -79,7 +79,7 @@ Classes
 Indefinite Type
 -----------------
 
-* A class wide type is an indefinite type
+* A class-wide type is an indefinite type
 
    - Just like an unconstrained array or a record with a discriminant
 
@@ -202,7 +202,7 @@ Warning: Subprograms with parameter of type `Root'Class` are not primitives of `
 'Class and Prefix Notation
 ----------------------------
 
-Prefix notation rules apply when the first parameter is of a class wide type
+Prefix notation rules apply when the first parameter is of a class-wide type
 
       .. code:: Ada
 
@@ -317,11 +317,11 @@ Calls on Class-Wide Types (3/3)
       ((Animal) *My_Dog).Feed ();
 
 -------------------------------
-Definite and Class Wide Views
+Definite and Class-Wide Views
 -------------------------------
 
 * In C++, dispatching occurs only on pointers
-* In Ada, dispatching occurs only on class wide views
+* In Ada, dispatching occurs only on class-wide views
 
 .. code:: Ada
 

--- a/courses/fundamentals_of_ada/adv_250_containers.rst
+++ b/courses/fundamentals_of_ada/adv_250_containers.rst
@@ -104,7 +104,7 @@ Data Structures (2/2)
 
 * Holder
 
-    - Wraps around an indefinite (unconstrained, classwide ...)
+    - Wraps around an indefinite (unconstrained, class-wide ...)
     - Resulting type is definite
     - Single element, no iteration or cursor
 

--- a/courses/static_analysis_via_compiler/010_static_analysis_via_compiler.rst
+++ b/courses/static_analysis_via_compiler/010_static_analysis_via_compiler.rst
@@ -971,14 +971,14 @@ OOP Restrictions
   + Allows
 
     + Record extensions
-    + Classwide membership tests
-    + Other classwide features
+    + Class-wide membership tests
+    + Other class-wide features
 
   + Does not allow involving implicit dispatching
 
   + Comparable to :ada:`No_Dispatch`
 
-    + Except allows all classwide constructs that do not imply dispatching
+    + Except allows all class-wide constructs that do not imply dispatching
 
 ------
 Quiz

--- a/marketing/ada_4_hours/180_polymorphism.rst
+++ b/marketing/ada_4_hours/180_polymorphism.rst
@@ -74,7 +74,7 @@ Abstract Types
 'Class and Prefix Notation
 ----------------------------
 
-Prefix notation rules apply when the first parameter is of a class wide type
+Prefix notation rules apply when the first parameter is of a class-wide type
 
 .. code:: Ada
 

--- a/marketing/ada_8_hours/180_polymorphism.rst
+++ b/marketing/ada_8_hours/180_polymorphism.rst
@@ -63,7 +63,7 @@ Classes
 Indefinite type
 -----------------
 
-* A class wide type is an indefinite type
+* A class-wide type is an indefinite type
 
    - Just like an unconstrained array or a record with a discriminant
 
@@ -172,7 +172,7 @@ Abstract Types Ada vs C++
 'Class and Prefix Notation
 ----------------------------
 
-Prefix notation rules apply when the first parameter is of a class wide type
+Prefix notation rules apply when the first parameter is of a class-wide type
 
       .. code:: Ada
 
@@ -282,11 +282,11 @@ Calls on class-wide types (3/3)
       ((Root) *V2).P ();
 
 -------------------------------
-Definite and class wide views
+Definite and Class-Wide views
 -------------------------------
 
 * In C++, dispatching occurs only on pointers
-* In Ada, dispatching occurs only on class wide views
+* In Ada, dispatching occurs only on class-wide views
 
 .. code:: Ada
 


### PR DESCRIPTION
This spelling is the one used in the LRM