### PR TITLE
Replace most occurrences of "element" with "component"

### DIFF
--- a/courses/fundamentals_of_ada/030_basic_types/06-character_types.rst
+++ b/courses/fundamentals_of_ada/030_basic_types/06-character_types.rst
@@ -9,19 +9,19 @@ Language-Defined Character Types
 * :ada:`Character`
 
    - 8-bit Latin-1
-   - Base element of :ada:`String`
+   - Base component of :ada:`String`
    - Uses attributes :ada:`'Image` / :ada:`'Value`
 
 * :ada:`Wide_Character`
 
    - 16-bit Unicode
-   - Base element of :ada:`Wide_Strings`
+   - Base component of :ada:`Wide_Strings`
    - Uses attributes :ada:`'Wide_Image` / :ada:`'Wide_Value`
 
 * :ada:`Wide_Wide_Character`
 
    - 32-bit Unicode
-   - Base element of :ada:`Wide_Wide_Strings`
+   - Base component of :ada:`Wide_Wide_Strings`
    - Uses attributes :ada:`'Wide_Wide_Image` / :ada:`'Wide_Wide_Value`
 
 -----------------------------

--- a/courses/fundamentals_of_ada/050_array_types/02-constrained_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types/02-constrained_array_types.rst
@@ -63,8 +63,8 @@ Quiz
 
     Explanations
 
-    A. Legal - elements are :ada:`Boolean`
+    A. Legal - components are :ada:`Boolean`
     B. Legal - object types match
-    C. Legal - elements are :ada:`Boolean`
-    D. Although the sizes are the same and the elements are the same, the type is different
+    C. Legal - components are :ada:`Boolean`
+    D. Although the sizes are the same and the components are the same, the type is different
 

--- a/courses/fundamentals_of_ada/050_array_types/03-unconstrained_array_types.rst
+++ b/courses/fundamentals_of_ada/050_array_types/03-unconstrained_array_types.rst
@@ -81,7 +81,7 @@ Null Index Range
 
 * When :ada:`'Last` of the range is smaller than :ada:`'First`
 
-  * Array is empty - no elements
+  * Array is empty - no components
 
 * When using literals, the compiler will allow out-of-range numbers to indicate empty range
 
@@ -189,7 +189,7 @@ Indefinite Types
 No Indefinite Component Types
 -------------------------------
 
-* Arrays: consecutive elements of the exact **same type**
+* Arrays: consecutive components of the exact **same type**
 * Component size must be **defined**
 
     - No indefinite types

--- a/courses/fundamentals_of_ada/050_array_types/05-operations.rst
+++ b/courses/fundamentals_of_ada/050_array_types/05-operations.rst
@@ -172,7 +172,7 @@ Which statement(s) is (are) legal?
    Explanations
 
    A. All objects are just Boolean values
-   B. An element of :ada:`A` is the same type as :ada:`B`
+   B. A component of :ada:`A` is the same type as :ada:`B`
    C. Slice must be of outermost array
    D. Slicing allowed on single-dimension arrays
 

--- a/courses/fundamentals_of_ada/050_array_types/06-looping_over_objects.rst
+++ b/courses/fundamentals_of_ada/050_array_types/06-looping_over_objects.rst
@@ -7,7 +7,7 @@ Note on Default Initialization for Array Types
 ------------------------------------------------
 
 * In Ada, objects are not initialized by default
-* To initialize an array, you can initialize each element
+* To initialize an array, you can initialize each component
 
    * But if the array type is used in multiple places, it would be better to initialize at the type level
    * No matter how many dimensions, there is only one component type
@@ -51,7 +51,7 @@ Two High-Level For-Loop Kinds
 Array/Container For-Loops
 ---------------------------
 
-* Work in terms of elements within an object
+* Work in terms of components within an object
 * Syntax hides indexing/iterator controls
 
    .. code:: Ada
@@ -60,7 +60,7 @@ Array/Container For-Loops
       ...
       end loop;
 
-* Starts with "first" element unless you reverse it
+* Starts with "first" component unless you reverse it
 * Loop parameter name is a constant if iterating over a constant, a variable otherwise
 
 ..

--- a/courses/fundamentals_of_ada/050_array_types/07-aggregates.rst
+++ b/courses/fundamentals_of_ada/050_array_types/07-aggregates.rst
@@ -269,7 +269,7 @@ Aggregates in Ada 2022
          Illegal : Array_T := ();
          Ada2022 : Array_T := [];
 
-   * Single element array
+   * Single component array
 
       .. code:: Ada
 
@@ -308,7 +308,7 @@ Iterated Component Association
 
       Object2 := [for Item of Object => Item * 2];
 
-   * :ada:`Object2` will have each element doubled
+   * :ada:`Object2` will have each component doubled
 
 -------------------------------
 More Information on Iterators

--- a/courses/fundamentals_of_ada/065_discriminated_records/02-variant_records.rst
+++ b/courses/fundamentals_of_ada/065_discriminated_records/02-variant_records.rst
@@ -116,7 +116,7 @@ Mutable Variant Record
 
    * An object can be created without a constraint (:ada:`Pat`)
    * Or we can create in immutable object where the discriminant cannot change (:ada:`Sam`)
-   * And we can create an array whose element is mutable
+   * And we can create an array whose component is mutable
 
 --------------------------------
 Mutable Variant Record Example

--- a/courses/fundamentals_of_ada/065_discriminated_records/03-discriminant_record_array_size_idiom.rst
+++ b/courses/fundamentals_of_ada/065_discriminated_records/03-discriminant_record_array_size_idiom.rst
@@ -19,12 +19,12 @@ Vectors of Varying Lengths
    + Need two pieces of data
 
       * Array contents
-      * Location of last valid element
+      * Location of last valid component
 
 * For common usage, we want this to be a type (probably a record)
 
    + Maximum size array for contents
-   + Index for last valid element
+   + Index for last valid component
 
 ---------------------------------
 Simple Vector of Varying Length

--- a/courses/fundamentals_of_ada/075_type_derivation/01-introduction.rst
+++ b/courses/fundamentals_of_ada/075_type_derivation/01-introduction.rst
@@ -18,7 +18,7 @@ Type Derivation
 Reminder: What is a Type?
 ---------------------------
 
-* A type is characterized by two elements
+* A type is characterized by two components
 
    - Its data structure
    - The set of operations that applies to it

--- a/courses/fundamentals_of_ada/080_expressions/05-quantified_expressions.rst
+++ b/courses/fundamentals_of_ada/080_expressions/05-quantified_expressions.rst
@@ -354,8 +354,8 @@ Quiz
    type Array2_T is array (1 .. 3) of Array1_T;
    A : Array2_T;
 
-The above describes an array A whose elements are arrays of three elements.
-Which expression would one use to determine if at least one of A's elements are sorted?
+The above describes an array A whose components are arrays of three components.
+Which expression would one use to determine if at least one of A's components are sorted?
 
 A. | ``(for some El of A => (for some Idx in 2 .. 3 =>``
    |     ``El (Idx) >= El (Idx - 1)));``
@@ -368,8 +368,8 @@ D. | ``(for all El of A => (for some Idx in 2 .. 3 =>``
 
 .. container:: animate
 
- A. Will be :ada:`True` if any element has two consecutive increasing values
- B. Will be :ada:`True` if every element is sorted
+ A. Will be :ada:`True` if any component has two consecutive increasing values
+ B. Will be :ada:`True` if every component is sorted
  C. Correct
- D. Will be :ada:`True` if every element has two consecutive increasing values
+ D. Will be :ada:`True` if every component has two consecutive increasing values
 

--- a/courses/fundamentals_of_ada/110_private_types/05-when_to_use_or_avoid_private_types.rst
+++ b/courses/fundamentals_of_ada/110_private_types/05-when_to_use_or_avoid_private_types.rst
@@ -39,7 +39,7 @@ When to Avoid Private Types
 
    - Those that cannot be redefined by programmers
    - Would otherwise be hidden by a private type
-   - If `Vector` is private, indexing of elements is annoying
+   - If `Vector` is private, indexing of components is annoying
 
       .. code:: Ada
 

--- a/courses/fundamentals_of_ada/120_limited_types/02-declarations.rst
+++ b/courses/fundamentals_of_ada/120_limited_types/02-declarations.rst
@@ -79,7 +79,7 @@ Composites with Limited Types
 
 * Composite containing a limited type becomes limited as well
 
-   * Example: Array of limited elements
+   * Example: Array of limited components
 
       - Array becomes a limited type
 

--- a/courses/fundamentals_of_ada/135_visibility/04-renaming_entities.rst
+++ b/courses/fundamentals_of_ada/135_visibility/04-renaming_entities.rst
@@ -68,7 +68,7 @@ The "renames" Keyword
 
          package Trig renames Math.Trigonometry
 
-   - Objects (or elements of objects)
+   - Objects (or components of objects)
 
       .. code:: Ada
 

--- a/courses/fundamentals_of_ada/135_visibility/05-lab.rst
+++ b/courses/fundamentals_of_ada/135_visibility/05-lab.rst
@@ -12,13 +12,13 @@ Visibility Lab
 
       + :ada:`Number_of_Sides` - indicates how many sides in the shape
       + :ada:`Side_T` - numeric value for length
-      + :ada:`Shape_T` - array of :ada:`Side_T` elements whose length is :ada:`Number_of_Sides`
+      + :ada:`Shape_T` - array of :ada:`Side_T` components whose length is :ada:`Number_of_Sides`
 
    - Create a main program that will
 
       + Create an object of each :ada:`Shape_T`
-      + Set the values for each element in :ada:`Shape_T`
-      + Add all the elements in each object and print the total
+      + Set the values for each component in :ada:`Shape_T`
+      + Add all the components in each object and print the total
 
 * Hints
 

--- a/courses/fundamentals_of_ada/160_genericity/03-generic_data_in_depth.rst
+++ b/courses/fundamentals_of_ada/160_genericity/03-generic_data_in_depth.rst
@@ -105,15 +105,15 @@ Generic Parameters Can Be Combined
       type Acc is access all T;
       type Index is (<>);
       type Arr is array (Index range <>) of Acc;
-   function Element (Source   : Arr;
-                     Position : Index)
-                     return T;
+   function Component (Source   : Arr;
+                       Position : Index)
+                       return T;
 
    type String_Ptr is access all String;
    type String_Array is array (Integer range <>)
        of String_Ptr;
 
-   function String_Element is new Element
+   function String_Component is new Component
       (T     => String,
        Acc   => String_Ptr,
        Index => Integer,

--- a/courses/fundamentals_of_ada/160_genericity/04-generic_formal_data_in_depth.rst
+++ b/courses/fundamentals_of_ada/160_genericity/04-generic_formal_data_in_depth.rst
@@ -27,9 +27,9 @@ Generic Constants/Variables As Parameters
        .. code:: Ada
 
           generic
-            type Element_T is private;
+            type Component_T is private;
             Array_Size     : Positive;
-            High_Watermark : in out Element_T;
+            High_Watermark : in out Component_T;
           package Repository is
 
      * Generic instance
@@ -40,7 +40,7 @@ Generic Constants/Variables As Parameters
          Max : Float;
 
          procedure My_Repository is new Repository
-           (Element_T      => Float,
+           (Component_T    => Float,
             Array_size     => 10,
             High_Watermark => Max);
 

--- a/courses/fundamentals_of_ada/230_interfacing_with_c/04-complex_data_types.rst
+++ b/courses/fundamentals_of_ada/230_interfacing_with_c/04-complex_data_types.rst
@@ -66,11 +66,11 @@ Arrays Interfacing
 Arrays From Ada to C
 ----------------------
 
-* An Ada array is a composite data structure containing 2 elements: Bounds and Elements
+* An Ada array is a composite data structure containing 2 components: Bounds and Components
 
    - **Fat pointers**
 
-* When arrays can be sent from Ada to C, C will only receive an access to the elements of the array
+* When arrays can be sent from Ada to C, C will only receive an access to the components of the array
 * Ada View
 
    .. code:: Ada

--- a/courses/fundamentals_of_ada/230_interfacing_with_c/05-interfacesc.rst
+++ b/courses/fundamentals_of_ada/230_interfacing_with_c/05-interfacesc.rst
@@ -107,21 +107,21 @@ Interfaces.C.Pointers
 
    generic
       type Index is (<>);
-      type Element is private;
-      type Element_Array is array (Index range <>) of aliased Element;
-      Default_Terminator : Element;
+      type Component is private;
+      type Component_Array is array (Index range <>) of aliased Component;
+      Default_Terminator : Component;
 
    package Interfaces.C.Pointers is
 
-      type Pointer is access all Element;
+      type Pointer is access all Component;
       for Pointer'Size use System.Parameters.ptr_bits;
 
       function Value (Ref        : Pointer;
-                      Terminator : Element := Default_Terminator)
-                      return Element_Array;
+                      Terminator : Component := Default_Terminator)
+                      return Component_Array;
       function Value (Ref    : Pointer;
                       Length : ptrdiff_t)
-                      return Element_Array;
+                      return Component_Array;
 
       Pointer_Error : exception;
 

--- a/courses/fundamentals_of_ada/270_introduction_to_contracts/02-preconditions_and_postconditions.rst
+++ b/courses/fundamentals_of_ada/270_introduction_to_contracts/02-preconditions_and_postconditions.rst
@@ -205,9 +205,9 @@ Quiz
 .. code:: Ada
 
    type Index_T is range 1 .. 100;
-   -- Database initialized such that value for element at I = I
+   -- Database initialized such that value for component at I = I
    Database : array (Index_T) of Integer;
-   -- Set the value for element Index to Value and
+   -- Set the value for component Index to Value and
    -- then increment Index by 1
    function Set_And_Move (Value :        Integer;
                           Index : in out Index_T)

--- a/courses/fundamentals_of_ada/273_subprogram_contracts/03-special_attributes.rst
+++ b/courses/fundamentals_of_ada/273_subprogram_contracts/03-special_attributes.rst
@@ -110,7 +110,7 @@ Quiz
 .. code:: Ada
 
    Database : String (1 .. 10) := "ABCDEFGHIJ";
-   -- Set the value for the element at position Index in
+   -- Set the value for the component at position Index in
    -- array Database to Value and then increment Index by 1
    function Set_And_Move (Value :        Character;
                           Index : in out Index_T)

--- a/courses/fundamentals_of_ada/890_ada_text_io/01-introduction.rst
+++ b/courses/fundamentals_of_ada/890_ada_text_io/01-introduction.rst
@@ -16,7 +16,7 @@ Ada.Text_IO
 
    - `Ada.Sequential_IO` and `Ada.Direct_IO`
 
-      * Operations on binary files for elements of a given type
+      * Operations on binary files for components of a given type
 
    - `Ada.Storage_IO`
 

--- a/courses/fundamentals_of_ada/894_ada_containers/02-container_types.rst
+++ b/courses/fundamentals_of_ada/894_ada_containers/02-container_types.rst
@@ -21,7 +21,7 @@ Data Structures (1/2)
     - Containers matching Key -> Element
     - Not a one-to-one relationship
 
-        + Can have several keys for a single element
+        + Can have several keys for a single component
 
 * Set
 
@@ -49,7 +49,7 @@ Data Structures (2/2)
 
     - Wraps around an indefinite (unconstrained, class-wide ...)
     - Resulting type is definite
-    - Single element, no iteration or cursor
+    - Single component, no iteration or cursor
 
 ..
   language_version 2012
@@ -61,7 +61,7 @@ Implementations (1/2)
 * :dfn:`Bounded`
 
     - Maximal storage is bounded
-    - Constant :dfn:`capacity` and element size
+    - Constant :dfn:`capacity` and component size
     - Only static allocation
     - :ada:`Bounded_<Structure>`
 
@@ -73,14 +73,14 @@ Implementations (1/2)
 
 * :dfn:`Ordered`
 
-    - Elements are sorted in order
+    - Components are sorted in order
     - Must provide :ada:`<` and :ada:`=` operators
     - Not hashed
     - :ada:`XXX_Ordered_<Structure>`
 
 * :dfn:`Hashed`
 
-    - Elements are hashed
+    - Components are hashed
     - Must provide :ada:`Hash` function and :ada:`=` operator
     - Not ordered
     - Some hash functions are provided (e.g. :ada:`Ada.Strings.Hash`)
@@ -92,8 +92,8 @@ Implementations (2/2)
 
 * :dfn:`Indefinite`
 
-    - Element can be indefinite
-    - Size of element is unknown
+    - Component can be indefinite
+    - Size of component is unknown
     - :ada:`Indefinite_XXX_<Structure>`
 
 ..
@@ -107,18 +107,18 @@ Example of Containers
 * :ada:`Indefinite_Vector`
 
     - Static capacity
-    - Dynamically sized (indefinite elements)
+    - Dynamically sized (indefinite components)
     - Random access in ``O(1)``
 
 * :ada:`Ordered_Set`
 
-    - Unique elements
+    - Unique components
     - Differentiated by :ada:`<` and :ada:`=`
     - Manipulated in order
 
 * :ada:`Bounded_Doubly_Linked_List`
 
-    - Static size of container and elements
+    - Static size of container and components
     - Insertions and deletions in ``O(1)``
 
 -------------

--- a/courses/fundamentals_of_ada/894_ada_containers/03-containers_operations.rst
+++ b/courses/fundamentals_of_ada/894_ada_containers/03-containers_operations.rst
@@ -24,7 +24,7 @@ Insertion
 
 * May be in order :ada:`Append` or :ada:`Prepend`
 * May be :ada:`Insert` (at random or at given index)
-* May :ada:`Replace` an existing element
+* May :ada:`Replace` an existing component
 
 .. code:: Ada
 
@@ -45,7 +45,7 @@ Iteration
 
 * Container has a :ada:`Cursor` type
 
-    - Points to an element in a container
+    - Points to a component in a container
     - Can be used for advanced iterations
 
 .. code:: Ada

--- a/courses/fundamentals_of_ada/901_ada_2022_specific.rst
+++ b/courses/fundamentals_of_ada/901_ada_2022_specific.rst
@@ -273,8 +273,8 @@ Container Aggregates
 * Args are
 
     - :ada:`Empty` init function (or else default)
-    - :ada:`Add_Named` named aggregate element
-    - :ada:`Add_Unnamed` positional aggregate element
+    - :ada:`Add_Named` named aggregate component
+    - :ada:`Add_Unnamed` positional aggregate component
 
 * You **cannot** mix named and unnamed
 

--- a/courses/fundamentals_of_ada/902_future_capabilities.rst
+++ b/courses/fundamentals_of_ada/902_future_capabilities.rst
@@ -278,7 +278,7 @@ Constant Size for Variable Objects (3/3)
 
 * Used size of the array can varry over time.
 
-* `'Capacity` will return maximum number of elements of an array
+* `'Capacity` will return maximum number of components of an array
 
 .. code:: Ada
 
@@ -369,7 +369,7 @@ Creation of Ada Array From Memory
       <stuff coming from either C or some memory buffer>.
 
    V : A := X'From_Address (S, 0, 10);
-   -- Create a fat pointer of 11 elements
+   -- Create a fat pointer of 11 components
    --   first = 0, last = 10, pointed to by S.
 
 * This also requires GNAT redesign of so-called fat pointers

--- a/courses/fundamentals_of_ada/examples/090_overloading/user_defined_equality.rst
+++ b/courses/fundamentals_of_ada/examples/090_overloading/user_defined_equality.rst
@@ -16,7 +16,7 @@
          else
             for I in 1 .. L.Count loop
                if L.Vector (I) /= R.Vector (I) then
-                  Put_Line ("elements don't match");
+                  Put_Line ("components don't match");
                   return False;
                end if;
             end loop;

--- a/courses/fundamentals_of_ada/labs/050_array_types.lab.rst
+++ b/courses/fundamentals_of_ada/labs/050_array_types.lab.rst
@@ -8,14 +8,14 @@ Array Lab
 
 * Requirements
 
-   - Create an array type whose index is days of the week and each element is a number
+   - Create an array type whose index is days of the week and each component is a number
    - Create two objects of the array type, one of which is constant
    - Perform the following operations
 
       + Copy the constant object to the non-constant object
       + Print the contents of the non-constant object
       + Use an array aggregate to initialize the non-constant object
-      + For each element of the array, print the array index and the value
+      + For each component of the array, print the array index and the value
       + Move part ("source") of the non-constant object to another part ("destination"), and then clear the source location
       + Print the contents of the non-constant object
 

--- a/courses/fundamentals_of_ada/labs/110_private_types.lab.rst
+++ b/courses/fundamentals_of_ada/labs/110_private_types.lab.rst
@@ -11,7 +11,7 @@ Private Types Lab
    - Implement a program to create a map such that
 
       + Map key is a description of a flag
-      + Map element content is the set of colors in the flag
+      + Map component content is the set of colors in the flag
 
    - Operations on the map should include: Add, Remove, Modify, Get, Exists, Image
    - Main program should print out the entire map before exiting
@@ -24,7 +24,7 @@ Private Types Lab
 
    - Should implement a **set** ADT (to keep track of the colors)
 
-      + This **set** will be the description of the map element
+      + This **set** will be the description of the map component
 
    - Each ADT should be its own package
    - At a minimum, the **map** and **set** type should be `private`

--- a/courses/fundamentals_of_ada/labs/135_visibility.lab.rst
+++ b/courses/fundamentals_of_ada/labs/135_visibility.lab.rst
@@ -12,13 +12,13 @@ Visibility Lab
 
       + :ada:`Number_of_Sides` - indicates how many sides in the shape
       + :ada:`Side_T` - numeric value for length
-      + :ada:`Shape_T` - array of :ada:`Side_T` elements whose length is :ada:`Number_of_Sides`
+      + :ada:`Shape_T` - array of :ada:`Side_T` components whose length is :ada:`Number_of_Sides`
 
    - Create a main program that will
 
       + Create an object of each :ada:`Shape_T`
-      + Set the values for each element in :ada:`Shape_T`
-      + Add all the elements in each object and print the total
+      + Set the values for each component in :ada:`Shape_T`
+      + Add all the components in each object and print the total
 
 * Hints
 

--- a/courses/fundamentals_of_ada/labs/160_genericity.lab.rst
+++ b/courses/fundamentals_of_ada/labs/160_genericity.lab.rst
@@ -21,8 +21,8 @@ Genericity Lab
 
 * Hints
 
-   - Sort routine will need to know how to compare elements
-   - Print routine will need to know how to print one element
+   - Sort routine will need to know how to compare components
+   - Print routine will need to know how to print one component
 
 ------------------------------------------
 Genericity Lab Solution - Generic (Spec)

--- a/courses/fundamentals_of_ada/labs/893_ada_numerics.lab.rst
+++ b/courses/fundamentals_of_ada/labs/893_ada_numerics.lab.rst
@@ -9,7 +9,7 @@ Ada.Numerics Lab
 * Create an array
 
   * Size of at least 5
-  * Element is a record containing
+  * Component is a record containing
 
     * Integer counter
     * Floating point total
@@ -17,8 +17,8 @@ Ada.Numerics Lab
 * Populate the array as follows
 
   * Loop some (large) number of times
-  * For each iteration of the loop, pick a random element in the array
-  * For the selected element
+  * For each iteration of the loop, pick a random component in the array
+  * For the selected component
 
     * Increment the counter component
     * Find a random floating point number between 1_000 and 9_999
@@ -27,7 +27,7 @@ Ada.Numerics Lab
 * For each index in the array
 
   * Print out the array index
-  * Print out the element counter
+  * Print out the component counter
   * Print out the average of the square roots
 
 * Observation

--- a/courses/fundamentals_of_ada/labs/answers/110_private_types.txt
+++ b/courses/fundamentals_of_ada/labs/answers/110_private_types.txt
@@ -51,7 +51,7 @@ end Colors;
 with Colors;
 package Flags is
    type Key_T is (USA, England, France, Italy);
-   type Map_Element_T is private;
+   type Map_Component_T is private;
    type Map_T is private;
 
    procedure Add (Map         : in out Map_T;
@@ -67,15 +67,15 @@ package Flags is
                      Success     :    out Boolean);
 
    function Exists (Map : Map_T; Key : Key_T) return Boolean;
-   function Get (Map : Map_T; Key : Key_T) return Map_Element_T;
-   function Image (Item : Map_Element_T) return String;
+   function Get (Map : Map_T; Key : Key_T) return Map_Component_T;
+   function Image (Item : Map_Component_T) return String;
    function Image (Flag : Map_T) return String;
 private
-   type Map_Element_T is record
+   type Map_Component_T is record
       Key         : Key_T := Key_T'First;
       Description : Colors.Color_Set_T := Colors.Empty_Set;
    end record;
-   type Map_Array_T is array (1 .. 100) of Map_Element_T;
+   type Map_Array_T is array (1 .. 100) of Map_Component_T;
    type Map_T is record
       Values : Map_Array_T;
       Length : Natural := 0;
@@ -107,7 +107,7 @@ package body Flags is
       Success := False;
       if Index not in Map.Values'Range then
          declare
-            New_Item : constant Map_Element_T :=
+            New_Item : constant Map_Component_T :=
               (Key         => Key,
                Description => Description);
          begin
@@ -152,9 +152,9 @@ package body Flags is
    
    function Get (Map : Map_T;
                  Key : Key_T)
-                 return Map_Element_T is
+                 return Map_Component_T is
       Index   : constant Integer := Find (Map, Key);
-      Ret_Val : Map_Element_T;
+      Ret_Val : Map_Component_T;
    begin
       if Index in Map.Values'Range then
          Ret_Val := Map.Values (Index);
@@ -162,7 +162,7 @@ package body Flags is
       return Ret_Val;
    end Get;
    
-   function Image (Item : Map_Element_T) return String is
+   function Image (Item : Map_Component_T) return String is
      (Item.Key'Image & " => " & Colors.Image (Item.Description));
    
    function Image (Flag : Map_T) return String is
@@ -171,8 +171,8 @@ package body Flags is
    begin
       for I in 1 .. Flag.Length loop
          declare
-            Item : constant Map_Element_T := Flag.Values (I);
-            Str  : constant String        := Image (Item);
+            Item : constant Map_Component_T := Flag.Values (I);
+            Str  : constant String          := Image (Item);
          begin
             Ret_Val (Next .. Next + Str'Length) := Image (Item) & ASCII.LF;
             Next                                := Next + Str'Length + 1;

--- a/courses/fundamentals_of_ada/labs/answers/140_access_types-in_depth.txt
+++ b/courses/fundamentals_of_ada/labs/answers/140_access_types-in_depth.txt
@@ -46,10 +46,10 @@ package Database_List is
    procedure Next (List : in out List_T);
    function End_Of_List (List : List_T) return Boolean;
    function Current (List : List_T) return Database_T;
-   procedure Insert (List    : in out List_T;
-                    Element :        Database_T);
-   procedure Delete (List    : in out List_T;
-                     Element :        Database_T);
+   procedure Insert (List      : in out List_T;
+                     Component :        Database_T);
+   procedure Delete (List      : in out List_T;
+                     Component :        Database_T);
    function Is_Empty (List : List_T) return Boolean;
 private
    type Linked_List_T;
@@ -104,28 +104,28 @@ package body Database_List is
 --Database_List_Helpers
 
 --Database_List_Substance
-   procedure Insert (List    : in out List_T;
-                    Element :        Database_T) is
-      New_Element : Linked_List_Ptr_T :=
-        new Linked_List_T'(Next => null, Content => Element);
+   procedure Insert (List      : in out List_T;
+                     Component :        Database_T) is
+      New_Component : Linked_List_Ptr_T :=
+        new Linked_List_T'(Next => null, Content => Component);
    begin
       if Is_Empty (List) then
-         List.Current := New_Element;
-         List.Head    := New_Element;
-      elsif Element < List.Head.Content then
-         New_Element.Next := List.Head;
-         List.Current     := New_Element;
-         List.Head        := New_Element;
+         List.Current := New_Component;
+         List.Head    := New_Component;
+      elsif Component < List.Head.Content then
+         New_Component.Next := List.Head;
+         List.Current       := New_Component;
+         List.Head          := New_Component;
       else
          declare
             Current : Linked_List_Ptr_T := List.Head;
          begin
-            while Current.Next /= null and then Current.Next.Content < Element
+            while Current.Next /= null and then Current.Next.Content < Component
             loop
                Current := Current.Next;
             end loop;
-            New_Element.Next := Current.Next;
-            Current.Next     := New_Element;
+            New_Component.Next := Current.Next;
+            Current.Next       := New_Component;
          end;
       end if;
       -- Uncomment next line when using debug/storage pools
@@ -135,12 +135,12 @@ package body Database_List is
    procedure Free is new Unchecked_Deallocation
      (Linked_List_T, Linked_List_Ptr_T);
    procedure Delete
-     (List    : in out List_T;
-      Element :        Database_T) is
+     (List      : in out List_T;
+      Component :        Database_T) is
       To_Delete : Linked_List_Ptr_T := null;
    begin
       if not Is_Empty (List) then
-         if List.Head.Content = Element then
+         if List.Head.Content = Component then
             To_Delete    := List.Head;
             List.Head    := List.Head.Next;
             List.Current := List.Head;
@@ -150,7 +150,7 @@ package body Database_List is
                Current  : Linked_List_Ptr_T := List.Head.Next;
             begin
                while Current /= null loop
-                  if Current.Content = Element then
+                  if Current.Content = Component then
                      To_Delete     := Current;
                      Previous.Next := Current.Next;
                   end if;
@@ -175,14 +175,14 @@ with Database;
 with Database_List;
 procedure Main is
    List    : Database_List.List_T;
-   Element : Database.Database_T;
+   Component : Database.Database_T;
 
    procedure Add is
       Value : constant String := Get_String ("Add");
    begin
       if Value'Length > 0 then
-         Element := Database.To_Database (Value);
-         Database_List.Insert (List, Element);
+         Component := Database.To_Database (Value);
+         Database_List.Insert (List, Component);
       end if;
    end Add;
 
@@ -190,8 +190,8 @@ procedure Main is
       Value : constant String := Get_String ("Delete");
    begin
       if Value'Length > 0 then
-         Element := Database.To_Database (Value);
-         Database_List.Delete (List, Element);
+         Component := Database.To_Database (Value);
+         Database_List.Delete (List, Component);
       end if;
    end Delete;
 
@@ -200,8 +200,8 @@ procedure Main is
       Database_List.First (List);
       Simple_Io.Print_String ("List");
       while not Database_List.End_Of_List (List) loop
-         Element := Database_List.Current (List);
-         Print_String ("  " & Database.From_Database (Element));
+         Component := Database_List.Current (List);
+         Print_String ("  " & Database.From_Database (Component));
          Database_List.Next (List);
       end loop;
    end Print;
@@ -301,7 +301,7 @@ end Memory_Mgmt;
 --Memory_Mgmt_Debug
 
 --Memory_Mgmt_Spec
-with System.Storage_Elements;
+with System.Storage_Components;
 with System.Storage_Pools;
 package Memory_Mgmt is
 
@@ -313,16 +313,16 @@ package Memory_Mgmt is
    procedure Allocate
      (Pool                     : in out Storage_Pool_T;
       Storage_Address          :    out System.Address;
-      Size_In_Storage_Elements :        System.Storage_Elements.Storage_Count;
-      Alignment                :        System.Storage_Elements.Storage_Count);
+      Size_In_Storage_Components :        System.Storage_Components.Storage_Count;
+      Alignment                :        System.Storage_Components.Storage_Count);
    procedure Deallocate
      (Pool                     : in out Storage_Pool_T;
       Storage_Address          :        System.Address;
-      Size_In_Storage_Elements :        System.Storage_Elements.Storage_Count;
-      Alignment                :        System.Storage_Elements.Storage_Count);
+      Size_In_Storage_Components :        System.Storage_Components.Storage_Count;
+      Alignment                :        System.Storage_Components.Storage_Count);
    function Storage_Size
      (Pool : Storage_Pool_T)
-      return System.Storage_Elements.Storage_Count;
+      return System.Storage_Components.Storage_Count;
 
    Storage_Pool : Storage_Pool_T;
 
@@ -333,7 +333,7 @@ end Memory_Mgmt;
 with Ada.Text_IO;
 with Interfaces;
 package body Memory_Mgmt is
-   use System.Storage_Elements;
+   use System.Storage_Components;
    use type System.Address;
 
    subtype Index_T is Storage_Count range 1 .. 1_000;
@@ -383,30 +383,30 @@ package body Memory_Mgmt is
    procedure Allocate
      (Pool                     : in out Storage_Pool_T;
       Storage_Address          :    out System.Address;
-      Size_In_Storage_Elements :        Storage_Count;
+      Size_In_Storage_Components :        Storage_Count;
       Alignment                :        Storage_Count) is
-      Index : Storage_Count := Find_Free_Block (Size_In_Storage_Elements);
+      Index : Storage_Count := Find_Free_Block (Size_In_Storage_Components);
    begin
       Storage_Address := Memory_Block (Index)'Address;
-      Set_In_Use (Index, Size_In_Storage_Elements, True);
+      Set_In_Use (Index, Size_In_Storage_Components, True);
    end Allocate;
 
    procedure Deallocate
      (Pool                     : in out Storage_Pool_T;
       Storage_Address          :        System.Address;
-      Size_In_Storage_Elements :        Storage_Count;
+      Size_In_Storage_Components :        Storage_Count;
       Alignment                :        Storage_Count) is
    begin
       for I in Memory_Block'Range loop
          if Memory_Block (I)'Address = Storage_Address then
-            Set_In_Use (I, Size_In_Storage_Elements, False);
+            Set_In_Use (I, Size_In_Storage_Components, False);
          end if;
       end loop;
    end Deallocate;
 
    function Storage_Size
      (Pool : Storage_Pool_T)
-      return System.Storage_Elements.Storage_Count is
+      return System.Storage_Components.Storage_Count is
    begin
       return 0;
    end Storage_Size;

--- a/courses/fundamentals_of_ada/labs/answers/160_genericity.txt
+++ b/courses/fundamentals_of_ada/labs/answers/160_genericity.txt
@@ -12,30 +12,30 @@ package Data_Type is
       else L.Integer_Component > R.Integer_Component);
 
    function Image
-     (Element : Record_T)
+     (Component : Record_T)
       return String is
-     (Element.Character_Component & " =>" & Integer'Image (Element.Integer_Component));
+     (Component.Character_Component & " =>" & Integer'Image (Component.Integer_Component));
 
 end Data_Type;
 
 --Generic_List_Spec
 generic
-   type Element_T is private;
+   type Component_T is private;
    Max_Size : Natural;
-   with function ">" (L, R : Element_T) return Boolean is <>;
-   with function Image (Element : Element_T) return String;
+   with function ">" (L, R : Component_T) return Boolean is <>;
+   with function Image (Component : Component_T) return String;
 package Generic_List is
 
    type List_T is private;
 
    procedure Add (This : in out List_T;
-                  Item : in     Element_T);
+                  Item : in     Component_T);
    procedure Sort (This : in out List_T);
    procedure Print (List : List_T);
 
 private
    subtype Index_T is Natural range 0 .. Max_Size;
-   type List_Array_T is array (1 .. Index_T'Last) of Element_T;
+   type List_Array_T is array (1 .. Index_T'Last) of Component_T;
 
    type List_T is record
       Values : List_Array_T;
@@ -49,14 +49,14 @@ with Ada.Text_io; use Ada.Text_IO;
 package body Generic_List is
 
    procedure Add (This : in out List_T;
-                  Item : in     Element_T) is
+                  Item : in     Component_T) is
    begin
       This.Length               := This.Length + 1;
       This.Values (This.Length) := Item;
    end Add;
 
    procedure Sort (This : in out List_T) is
-      Temp : Element_T;
+      Temp : Component_T;
    begin
       for I in 1 .. This.Length loop
          for J in 1 .. This.Length - I loop
@@ -83,13 +83,13 @@ end Generic_List;
 with Data_Type;
 with Generic_List;
 procedure Main is
-   package List is new Generic_List (Element_T => Data_Type.Record_T,
+   package List is new Generic_List (Component_T => Data_Type.Record_T,
                                      Max_Size  => 20,
                                      ">"       => Data_Type.">",
                                      Image => Data_Type.Image);
 
    My_List : List.List_T;
-   Element : Data_Type.Record_T;
+   Component : Data_Type.Record_T;
 
 begin
    List.Add (My_List, (Integer_Component   => 111,

--- a/courses/fundamentals_of_ada/labs/answers/190_exceptions-in_depth.txt
+++ b/courses/fundamentals_of_ada/labs/answers/190_exceptions-in_depth.txt
@@ -254,7 +254,7 @@ begin
       begin
          exit when Input'Length = 0;
          Parser (Input, Left, Operator, Right);
-         case Element (Operator, 1) is
+         case Component (Operator, 1) is
             when '+' =>
                Put_Line
                  ("  => " &

--- a/courses/fundamentals_of_ada/labs/answers/893_ada_numerics.txt
+++ b/courses/fundamentals_of_ada/labs/answers/893_ada_numerics.txt
@@ -7,11 +7,11 @@ procedure Main is
    package Io is new Float_IO (Float);
 
    type Index_T is range 1 .. 10;
-   type Element_T is record
+   type Component_T is record
       Count : Natural := 0;
       Total : Float   := 0.0;
    end record;
-   Values : array (Index_T) of Element_T;
+   Values : array (Index_T) of Component_T;
    Index  : Index_T;
 
    package I_Random is new Ada.Numerics.Discrete_Random (Index_T);

--- a/courses/fundamentals_of_ada/labs/answers/ada95/110_private_types.txt
+++ b/courses/fundamentals_of_ada/labs/answers/ada95/110_private_types.txt
@@ -61,7 +61,7 @@ end Colors;
 with Colors;
 package Flags is
    type Key_T is (USA, England, France, Italy);
-   type Map_Element_T is private;
+   type Map_Component_T is private;
    type Map_T is private;
 
    procedure Add (Map         : in out Map_T;
@@ -77,15 +77,15 @@ package Flags is
                      Success     :    out Boolean);
 
    function Exists (Map : Map_T; Key : Key_T) return Boolean;
-   function Get (Map : Map_T; Key : Key_T) return Map_Element_T;
-   function Image (Item : Map_Element_T) return String;
+   function Get (Map : Map_T; Key : Key_T) return Map_Component_T;
+   function Image (Item : Map_Component_T) return String;
    function Image (Flag : Map_T) return String;
 private
-   type Map_Element_T is record
+   type Map_Component_T is record
       Key         : Key_T := Key_T'First;
       Description : Colors.Color_Set_T := Colors.Empty_Set;
    end record;
-   type Map_Array_T is array (1 .. 100) of Map_Element_T;
+   type Map_Array_T is array (1 .. 100) of Map_Component_T;
    type Map_T is record
       Values : Map_Array_T;
       Length : Natural := 0;
@@ -117,7 +117,7 @@ package body Flags is
       Success := False;
       if Index not in Map.Values'Range then
          declare
-            New_Item : constant Map_Element_T :=
+            New_Item : constant Map_Component_T :=
               (Key         => Key,
                Description => Description);
          begin
@@ -164,9 +164,9 @@ package body Flags is
    
    function Get (Map : Map_T;
                  Key : Key_T)
-                 return Map_Element_T is
+                 return Map_Component_T is
       Index   : constant Integer := Find (Map, Key);
-      Ret_Val : Map_Element_T;
+      Ret_Val : Map_Component_T;
    begin
       if Index in Map.Values'Range then
          Ret_Val := Map.Values (Index);
@@ -174,7 +174,7 @@ package body Flags is
       return Ret_Val;
    end Get;
    
-   function Image (Item : Map_Element_T) return String is
+   function Image (Item : Map_Component_T) return String is
    begin
       return Key_T'Image (Item.Key) & " => " & Colors.Image (Item.Description);
    end Image;
@@ -185,7 +185,7 @@ package body Flags is
    begin
       for I in 1 .. Flag.Length loop
          declare
-            Item : constant Map_Element_T := Flag.Values (I);
+            Item : constant Map_Component_T := Flag.Values (I);
             Str  : constant String        := Image (Item);
          begin
             Ret_Val (Next .. Next + Str'Length) := Image (Item) & ASCII.LF;

--- a/courses/fundamentals_of_ada/labs/answers/ada95/160_genericity.txt
+++ b/courses/fundamentals_of_ada/labs/answers/ada95/160_genericity.txt
@@ -6,7 +6,7 @@ package Data_Type is
 
    function ">" (L, R : Record_T) return Boolean;
 
-   function Image (Element : Record_T) return String;
+   function Image (Component : Record_T) return String;
 
 end Data_Type;
 
@@ -23,32 +23,32 @@ package body Data_Type is
       end if;
    end ">";
 
-   function Image (Element : Record_T) return String is
+   function Image (Component : Record_T) return String is
    begin
-      return Element.Character_Component & " =>" &
-             Integer'Image (Element.Integer_Component);
+      return Component.Character_Component & " =>" &
+             Integer'Image (Component.Integer_Component);
    end Image;
 
 end Data_Type;
 
 --Generic_List_Spec
 generic
-   type Element_T is private;
+   type Component_T is private;
    Max_Size : Natural;
-   with function ">" (L, R : Element_T) return Boolean;
-   with function Image (Element : Element_T) return String;
+   with function ">" (L, R : Component_T) return Boolean;
+   with function Image (Component : Component_T) return String;
 package Generic_List is
 
    type List_T is private;
 
    procedure Add (This : in out List_T;
-                  Item : in     Element_T);
+                  Item : in     Component_T);
    procedure Sort (This : in out List_T);
    procedure Print (List : List_T);
 
 private
    subtype Index_T is Natural range 0 .. Max_Size;
-   type List_Array_T is array (1 .. Index_T'Last) of Element_T;
+   type List_Array_T is array (1 .. Index_T'Last) of Component_T;
 
    type List_T is record
       Values : List_Array_T;
@@ -62,14 +62,14 @@ with Ada.Text_IO; use Ada.Text_IO;
 package body Generic_List is
 
    procedure Add (This : in out List_T;
-                  Item : in     Element_T) is
+                  Item : in     Component_T) is
    begin
       This.Length               := This.Length + 1;
       This.Values (This.Length) := Item;
    end Add;
 
    procedure Sort (This : in out List_T) is
-      Temp : Element_T;
+      Temp : Component_T;
    begin
       for I in 1 .. This.Length loop
          for J in 1 .. This.Length - I loop
@@ -96,13 +96,13 @@ end Generic_List;
 with Data_Type;
 with Generic_List;
 procedure Main is
-   package List is new Generic_List (Element_T => Data_Type.Record_T,
+   package List is new Generic_List (Component_T => Data_Type.Record_T,
                                      Max_Size  => 20,
                                      ">"       => Data_Type.">",
                                      Image     => Data_Type.Image);
 
    My_List : List.List_T;
-   Element : Data_Type.Record_T;
+   Component : Data_Type.Record_T;
 
 begin
    List.Add (My_List, (Integer_Component   => 111,

--- a/courses/fundamentals_of_ada/labs/prompts/110_private_types/flags.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/110_private_types/flags.adb
@@ -8,7 +8,7 @@ package body Flags is
    begin
       Success := False;
       -- If the key is not already in the map then
-      --    Create a map element and add it to the map
+      --    Create a map component and add it to the map
    end Add;
 
    procedure Remove
@@ -17,7 +17,7 @@ package body Flags is
       Success :    out Boolean) is
    begin
       Success := False;
-      -- Remove the element specified by the key from the map
+      -- Remove the component specified by the key from the map
    end Remove;
 
    procedure Modify
@@ -27,7 +27,7 @@ package body Flags is
       Success     :    out Boolean) is
    begin
       Success := False;
-      -- Update the element at the key location with the new data
+      -- Update the component at the key location with the new data
    end Modify;
 
    function Exists
@@ -42,18 +42,18 @@ package body Flags is
    function Get
      (Map : Map_T;
       Key : Key_T)
-      return Map_Element_T is
-      Ret_Val : Map_Element_T;
+      return Map_Component_T is
+      Ret_Val : Map_Component_T;
    begin
-      -- Return the map element specified by key
+      -- Return the map component specified by key
       return Ret_Val;
    end Get;
 
    function Image
-     (Item : Map_Element_T)
+     (Item : Map_Component_T)
       return String is
    begin
-      -- return a string representation of the element
+      -- return a string representation of the component
       return "";
    end Image;
 

--- a/courses/fundamentals_of_ada/labs/prompts/110_private_types/flags.ads
+++ b/courses/fundamentals_of_ada/labs/prompts/110_private_types/flags.ads
@@ -1,8 +1,8 @@
 with Colors;
 package Flags is
-   -- For a map, we need a key and an element type
+   -- For a map, we need a key and a component type
    type Key_T is new Integer; -- implement something smarter!
-   type Map_Element_T is private;
+   type Map_Component_T is private;
    type Map_T is private;
 
    procedure Add
@@ -27,15 +27,15 @@ package Flags is
    function Get
      (Map : Map_T;
       Key : Key_T)
-      return Map_Element_T;
+      return Map_Component_T;
    function Image
-     (Item : Map_Element_T)
+     (Item : Map_Component_T)
       return String;
    function Image
      (Flag : Map_T)
       return String;
 private
    -- Implement these types
-   type Map_Element_T is null record;
+   type Map_Component_T is null record;
    type Map_T is null record;
 end Flags;

--- a/courses/fundamentals_of_ada/labs/prompts/135_visibility/main.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/135_visibility/main.adb
@@ -13,11 +13,11 @@ procedure Main is
 begin
 
    null;
-   -- for each element in Quad
+   -- for each component in Quad
    --    add Side to Total
    -- Print total
 
-   -- for each element in Triangle
+   -- for each component in Triangle
    --    add Side to Total
    -- Print total
 

--- a/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/database_list.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/database_list.adb
@@ -33,15 +33,15 @@ package body Database_List is
    end Current;
 
    procedure Insert
-     (List    : in out List_T;
-      Element :        Database_T) is
+     (List      : in out List_T;
+      Component :        Database_T) is
    begin
       null;
    end Insert;
 
    procedure Delete
-     (List    : in out List_T;
-      Element :        Database_T) is
+     (List      : in out List_T;
+      Component :        Database_T) is
    begin
       null;
    end Delete;

--- a/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/database_list.ads
+++ b/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/database_list.ads
@@ -10,11 +10,11 @@ package Database_List is
      (List : List_T)
       return Database_T;
    procedure Insert
-     (List    : in out List_T;
-      Element :        Database_T);
+     (List      : in out List_T;
+      Component :        Database_T);
    procedure Delete
-     (List    : in out List_T;
-      Element :        Database_T);
+     (List      : in out List_T;
+      Component :        Database_T);
    function Is_Empty
      (List : List_T)
       return Boolean;

--- a/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/main.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/140_access_types-in_depth/main.adb
@@ -5,15 +5,15 @@ with Simple_Io; use Simple_Io;
 with Database;
 with Database_List;
 procedure Main is
-   List    : Database_List.List_T;
-   Element : Database.Database_T;
+   List      : Database_List.List_T;
+   Component : Database.Database_T;
 
    procedure Add is
       Value : constant String := Get_String ("Add");
    begin
       if Value'Length > 0 then
-         Element := Database.To_Database (Value);
-         Database_List.Insert (List, Element);
+         Component := Database.To_Database (Value);
+         Database_List.Insert (List, Component);
       end if;
    end Add;
 
@@ -21,8 +21,8 @@ procedure Main is
       Value : constant String := Get_String ("Delete");
    begin
       if Value'Length > 0 then
-         Element := Database.To_Database (Value);
-         Database_List.Delete (List, Element);
+         Component := Database.To_Database (Value);
+         Database_List.Delete (List, Component);
       end if;
    end Delete;
 
@@ -31,8 +31,8 @@ procedure Main is
       Database_List.First (List);
       Simple_Io.Print_String ("List");
       while not Database_List.End_Of_List (List) loop
-         Element := Database_List.Current (List);
-         Print_String ("  " & Database.From_Database (Element));
+         Component := Database_List.Current (List);
+         Print_String ("  " & Database.From_Database (Component));
          Database_List.Next (List);
       end loop;
    end Print;

--- a/courses/fundamentals_of_ada/labs/prompts/160_genericity/data_type.ads
+++ b/courses/fundamentals_of_ada/labs/prompts/160_genericity/data_type.ads
@@ -6,7 +6,7 @@ package Data_Type is
       return Boolean is (True);  --  Update to Return True when L < R
 
    function Image
-     (Element : Record_T)
+     (Component : Record_T)
       return String is
      ("");  -- Update to return string representation of Record_T;
 

--- a/courses/fundamentals_of_ada/labs/prompts/160_genericity/generic_list.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/160_genericity/generic_list.adb
@@ -2,14 +2,14 @@ package body Generic_List is
 
    procedure Add
      (This : in out List_T;
-      Item : in     Element_T) is
+      Item : in     Component_T) is
    begin
       null;
    end Add;
 
    procedure Sort (This : in out List_T) is
-      Temp : Element_T;
-      --  Set length to number of elements in list
+      Temp : Component_T;
+      --  Set length to number of components in list
       Length : constant Integer := 0;
    begin
       for I in 1 .. Length
@@ -25,7 +25,7 @@ package body Generic_List is
 
    procedure Print (List : List_T) is
    begin
-      null;  --  Print each element in list
+      null;  --  Print each component in list
    end Print;
 
 end Generic_List;

--- a/courses/fundamentals_of_ada/labs/prompts/160_genericity/generic_list.ads
+++ b/courses/fundamentals_of_ada/labs/prompts/160_genericity/generic_list.ads
@@ -1,21 +1,21 @@
 generic
-   type Element_T is private;
+   type Component_T is private;
    --  Add other parameters for:
    --    Maximum size of list
-   --    Compare to elements
-   --    Convert element to string
+   --    Compare to components
+   --    Convert component to string
 package Generic_List is
 
    type List_T is private;
 
    procedure Add
      (This : in out List_T;
-      Item : in     Element_T);
+      Item : in     Component_T);
    procedure Sort (This : in out List_T);
    procedure Print (List : List_T);
 
 private
-   --  Update List_T to be a collection of Element_T
+   --  Update List_T to be a collection of Component_T
    type List_T is null record;
 
 end Generic_List;

--- a/courses/fundamentals_of_ada/labs/prompts/160_genericity/main.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/160_genericity/main.adb
@@ -1,17 +1,17 @@
 with Data_Type;
 with Generic_List;
 procedure Main is
-   package List is new Generic_List (Element_T => Data_Type.Record_T);
+   package List is new Generic_List (Component_T => Data_Type.Record_T);
    --  Need to add formal parameters as necessary
 
    My_List : List.List_T;
-   Element : Data_Type.Record_T;
+   Component : Data_Type.Record_T;
 
 begin
    --  Add some items to the list
-   List.Add (My_List, Element);
-   List.Add (My_List, Element);
-   List.Add (My_List, Element);
+   List.Add (My_List, Component);
+   List.Add (My_List, Component);
+   List.Add (My_List, Component);
 
    List.Sort (My_List);
    List.Print (My_List);

--- a/courses/fundamentals_of_ada/labs/prompts/893_ada_numerics/main.adb
+++ b/courses/fundamentals_of_ada/labs/prompts/893_ada_numerics/main.adb
@@ -4,14 +4,14 @@ procedure Main is
    package Io is new Float_IO (Float);
 
    type Index_T is range 1 .. 10;
-   type Element_T is null record; -- fix this
-   Values : array (Index_T) of Element_T;
+   type Component_T is null record; -- fix this
+   Values : array (Index_T) of Component_T;
 
 begin
    for I in 1 .. 100 loop -- bigger than 100 is good
       null;
       -- Find a random array index
-      -- Set the indexed element as specified
+      -- Set the indexed component as specified
    end loop;
 
    for I in Index_T'Range loop

--- a/courses/fundamentals_of_ada/mini_projects/cinema/answer/display/drawable_chars.ads
+++ b/courses/fundamentals_of_ada/mini_projects/cinema/answer/display/drawable_chars.ads
@@ -13,16 +13,16 @@ package Drawable_Chars is
    type Drawable_Charset_T
      is array (Positive range <>) of Drawable_Char_Access_T;
    -- Set of unique Drawable_Char_T that form together
-   -- a coherent set of primitive drawing elements.
+   -- a coherent set of primitive drawing components.
    
    type Drawable_Char_Characteristic_T is new Integer;
-   -- Characteristic attached to every elements of a Drawable_Charset_T
+   -- Characteristic attached to every components of a Drawable_Charset_T
    -- e.g. how much of that drawing primitive is black
-   -- This is then used to map those elements to pixels based on
+   -- This is then used to map those components to pixels based on
    -- e.g. luminosity information
 
    type Sorted_Charset_T is private;
-   -- Set of sorted drawable elements, this is a palette,
+   -- Set of sorted drawable components, this is a palette,
    -- from which images can be rendered to console.
 
    function Empty (SC : Sorted_Charset_T) return Boolean;

--- a/courses/fundamentals_of_ada/mini_projects/cinema/src/display/drawable_chars.ads
+++ b/courses/fundamentals_of_ada/mini_projects/cinema/src/display/drawable_chars.ads
@@ -13,16 +13,16 @@ package Drawable_Chars is
    type Drawable_Charset_T
      is array (Positive range <>) of Drawable_Char_Access_T;
    -- Set of unique Drawable_Char_T that form together
-   -- a coherent set of primitive drawing elements.
+   -- a coherent set of primitive drawing components.
    
    type Drawable_Char_Characteristic_T is new Integer;
-   -- Characteristic attached to every elements of a Drawable_Charset_T
+   -- Characteristic attached to every components of a Drawable_Charset_T
    -- e.g. how much of that drawing primitive is black
-   -- This is then used to map those elements to pixels based on
+   -- This is then used to map those components to pixels based on
    -- e.g. luminosity information
 
    type Sorted_Charset_T is private;
-   -- Set of sorted drawable elements, this is a palette,
+   -- Set of sorted drawable components, this is a palette,
    -- from which images can be rendered to console.
 
    function Empty (SC : Sorted_Charset_T) return Boolean;

--- a/courses/fundamentals_of_ada/mini_projects/cinema/template/display/drawable_chars.ads
+++ b/courses/fundamentals_of_ada/mini_projects/cinema/template/display/drawable_chars.ads
@@ -13,16 +13,16 @@ package Drawable_Chars is
    type Drawable_Charset_T
      is array (Positive range <>) of Drawable_Char_Access_T;
    -- Set of unique Drawable_Char_T that form together
-   -- a coherent set of primitive drawing elements.
+   -- a coherent set of primitive drawing components.
    
    type Drawable_Char_Characteristic_T is new Integer;
-   -- Characteristic attached to every elements of a Drawable_Charset_T
+   -- Characteristic attached to every components of a Drawable_Charset_T
    -- e.g. how much of that drawing primitive is black
-   -- This is then used to map those elements to pixels based on
+   -- This is then used to map those components to pixels based on
    -- e.g. luminosity information
 
    type Sorted_Charset_T is private;
-   -- Set of sorted drawable elements, this is a palette,
+   -- Set of sorted drawable components, this is a palette,
    -- from which images can be rendered to console.
 
    function Empty (SC : Sorted_Charset_T) return Boolean;

--- a/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/quiz.rst
@@ -5,9 +5,9 @@
 .. code:: Ada
 
        generic
-          type Element_T is (<>);
-          Last : in out Element_T;
-       procedure Write (P : Element_T);
+          type Component_T is (<>);
+          Last : in out Component_T;
+       procedure Write (P : Component_T);
     
        Numeric        : Integer;
        Enumerated     : Boolean;

--- a/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/template/main.adb
+++ b/courses/fundamentals_of_ada/quiz/genericity_type_and_variable/template/main.adb
@@ -3,16 +3,16 @@
 procedure Main is
    --$ begin question
    generic
-      type Element_T is (<>);
-      Last : in out Element_T;
-   procedure Write (P : Element_T);
+      type Component_T is (<>);
+      Last : in out Component_T;
+   procedure Write (P : Component_T);
 
    Numeric        : Integer;
    Enumerated     : Boolean;
    Floating_Point : Float;
    --$ end question
 
-   procedure Write (P : Element_T) is
+   procedure Write (P : Component_T) is
    begin
       Last := P;
    end Write;

--- a/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/quiz.rst
+++ b/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/quiz.rst
@@ -6,7 +6,7 @@
 
     type My_Array is array (Integer range <>) of Boolean;
 
-How to declare an array of two elements?
+How to declare an array of two components?
 
 A. ``O : My_Array (2)``
 B. :answermono:`O : My_Array (1 .. 2)`

--- a/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/template/main.adb
+++ b/courses/fundamentals_of_ada/quiz/unconstrained_arrays_declaration/template/main.adb
@@ -1,4 +1,4 @@
---  How to declare an array of two elements?
+--  How to declare an array of two components?
 procedure Main is
    --$ line question
    type My_Array is array (Integer range <>) of Boolean;


### PR DESCRIPTION
Runtime packages use "element" as a function name - can't change There's a quotation that uses the word "element" - can't change Also needed to fix grammer - "an element" to "a component"